### PR TITLE
fix: pre-flight KeyError in _send_tx

### DIFF
--- a/bnbagent/core/contract_mixin.py
+++ b/bnbagent/core/contract_mixin.py
@@ -55,11 +55,11 @@ class ContractClientMixin:
                 if not skip_preflight:
                     import concurrent.futures as _cf
                     _call_params = {
-                        "from": tx["from"],
-                        "to": tx["to"],
-                        "data": tx["data"],
+                        "from": self._account,
+                        "to": tx.get("to"),
+                        "data": tx.get("data", "0x"),
                         "value": tx.get("value", 0),
-                        "gas": tx["gas"],
+                        "gas": tx.get("gas", gas),
                     }
                     with _cf.ThreadPoolExecutor(max_workers=1) as _pool:
                         _future = _pool.submit(self.w3.eth.call, _call_params)


### PR DESCRIPTION
## Summary
- PR #17 introduced pre-flight `eth_call` simulation in `_send_tx` that reads `tx["from"]` after `build_transaction()`, causing `KeyError` when the returned tx dict doesn't contain that key
- Fix: use `self._account` directly (the value we already know) and `.get()` for other fields

## Changes
`bnbagent/core/contract_mixin.py`: replace `tx["from/to/data/gas"]` with `self._account` and `.get()` fallbacks in pre-flight params

## Test
423 passed, 0 failed