### PR TITLE
Fix path traversal in LocalStorageProvider.save_sync

### DIFF
--- a/bnbagent/storage/local_provider.py
+++ b/bnbagent/storage/local_provider.py
@@ -48,7 +48,10 @@ class LocalStorageProvider(StorageProvider):
                     hash_hex = self.compute_hash(data).hex()
                     fname = f"{hash_hex}.json"
 
-            filepath = self._base / fname
+            filepath = (self._base / fname).resolve()
+            base_resolved = self._base.resolve()
+            if not filepath.is_relative_to(base_resolved):
+                raise StorageError("Path traversal blocked: path is outside storage directory")
             filepath.write_text(content, encoding="utf-8")
             # Restrict file permissions to owner only (rw-------)
             os.chmod(filepath, stat.S_IRUSR | stat.S_IWUSR)

--- a/tests/test_local_storage.py
+++ b/tests/test_local_storage.py
@@ -59,6 +59,11 @@ class TestLocalStorageProvider:
         assert url.startswith("file://")
         assert "sync-test.json" in url
 
+    def test_save_sync_path_traversal_blocked(self, tmp_path):
+        provider = LocalStorageProvider(str(tmp_path / "data"))
+        with pytest.raises(StorageError, match="Path traversal blocked"):
+            provider.save_sync({"sync": True}, "../escape.json")
+
     @pytest.mark.asyncio
     async def test_download_success(self, tmp_path):
         provider = LocalStorageProvider(str(tmp_path / "data"))


### PR DESCRIPTION
## Summary
- block path traversal in `LocalStorageProvider.save_sync()` by resolving the target path before writing
- raise `StorageError` when a provided filename escapes the configured storage directory
- add a regression test covering `../escape.json`

## Why
`LocalStorageProvider` already blocked path traversal on read (`download`/`exists`), and the storage docs say traversal is blocked. However, `save_sync()` still wrote to `self._base / filename` without checking whether the resolved path stayed inside `base_dir`.

This meant a caller could pass a filename like `../escape.json` and write outside the configured storage directory.

## Testing
- `source /tmp/venv/bin/activate && pytest -q tests/test_local_storage.py`
