### PR TITLE
fix(storage): block path traversal in LocalStorageProvider.upload

### DIFF
--- a/bnbagent/storage/README.md
+++ b/bnbagent/storage/README.md
@@ -86,7 +86,7 @@ Async abstract base class. Subclass this to build a custom backend.
 
 | Method | Description |
 |---|---|
-| `async upload(data, filename=None)` | Upload JSON dict. Returns a URL (`file://`, `ipfs://`, `https://`…). |
+| `async upload(data, filename=None)` | Upload JSON dict. Returns a URL (`file://`, `ipfs://`, `https://`…). Implementations must reject `filename` values that resolve outside the storage scope by raising `StorageError`. |
 | `async download(url)` | Download and parse JSON from a URL. |
 | `async exists(url)` | Check whether data at the URL exists. |
 | `compute_hash(data)` (static) | `keccak256` of canonical JSON for on-chain verification. |

--- a/bnbagent/storage/local_storage_provider.py
+++ b/bnbagent/storage/local_storage_provider.py
@@ -42,7 +42,7 @@ class LocalStorageProvider(StorageProvider):
                 job_data = data.get("job", {})
                 job_id = job_data.get("id") if isinstance(job_data, dict) else None
                 fname = f"job-{job_id}.json" if job_id else f"{self.compute_hash(data).hex()}.json"
-            filepath = self._base / fname
+            filepath = self._safe_join(fname)
             filepath.write_text(content, encoding="utf-8")
             os.chmod(filepath, stat.S_IRUSR | stat.S_IWUSR)
             logger.info(f"[LocalStorageProvider] Saved to {filepath}")
@@ -74,8 +74,11 @@ class LocalStorageProvider(StorageProvider):
 
     def _url_to_path(self, url: str) -> str:
         raw = url[7:] if url.startswith("file://") else url
-        resolved = Path(raw).resolve()
+        return str(self._safe_join(raw))
+
+    def _safe_join(self, fname: str) -> Path:
+        candidate = (self._base / fname).resolve()
         base_resolved = self._base.resolve()
-        if not resolved.is_relative_to(base_resolved):
+        if not candidate.is_relative_to(base_resolved):
             raise StorageError("Path traversal blocked: path is outside storage directory")
-        return str(resolved)
+        return candidate

--- a/bnbagent/storage/storage_provider.py
+++ b/bnbagent/storage/storage_provider.py
@@ -41,6 +41,9 @@ class StorageProvider(ABC):
         Args:
             data: JSON-serializable dict to upload
             filename: Optional filename hint (e.g., "job-123.json")
+
+        Implementations MUST reject ``filename`` values that resolve outside
+        their storage scope and raise ``StorageError``.
         """
         ...
 

--- a/tests/test_local_storage.py
+++ b/tests/test_local_storage.py
@@ -102,6 +102,46 @@ class TestLocalStorageProvider:
         assert await provider.exists(f"file://{missing}") is False
 
     @pytest.mark.asyncio
+    async def test_upload_path_traversal_relative(self, tmp_path):
+        provider = LocalStorageProvider(str(tmp_path / "data"))
+        with pytest.raises(StorageError, match="Path traversal blocked"):
+            await provider.upload({"k": "v"}, "../escape.json")
+        assert not (tmp_path / "escape.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_upload_path_traversal_absolute(self, tmp_path):
+        provider = LocalStorageProvider(str(tmp_path / "data"))
+        outside = tmp_path / "outside.json"
+        with pytest.raises(StorageError, match="Path traversal blocked"):
+            await provider.upload({"k": "v"}, str(outside))
+        assert not outside.exists()
+
+    @pytest.mark.asyncio
+    async def test_upload_path_traversal_nested(self, tmp_path):
+        provider = LocalStorageProvider(str(tmp_path / "data"))
+        with pytest.raises(StorageError, match="Path traversal blocked"):
+            await provider.upload({"k": "v"}, "a/../../escape.json")
+        assert not (tmp_path / "escape.json").exists()
+
+    @pytest.mark.asyncio
+    async def test_upload_path_traversal_via_symlink(self, tmp_path):
+        base = tmp_path / "data"
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        provider = LocalStorageProvider(str(base))
+        (base / "link").symlink_to(outside, target_is_directory=True)
+        with pytest.raises(StorageError, match="Path traversal blocked"):
+            await provider.upload({"k": "v"}, "link/escape.json")
+        assert not (outside / "escape.json").exists()
+
+    def test_upload_sync_path_traversal_blocked(self, tmp_path):
+        from bnbagent.storage import upload_sync
+        provider = LocalStorageProvider(str(tmp_path / "data"))
+        with pytest.raises(StorageError, match="Path traversal blocked"):
+            upload_sync(provider, {"k": "v"}, "../escape.json")
+        assert not (tmp_path / "escape.json").exists()
+
+    @pytest.mark.asyncio
     async def test_download_path_traversal_blocked(self, tmp_path):
         provider = LocalStorageProvider(str(tmp_path / "data"))
         with pytest.raises(StorageError, match="Path traversal blocked"):


### PR DESCRIPTION
## Summary

- Block path traversal in `LocalStorageProvider.upload()` by resolving the candidate write path and verifying it stays inside the configured base directory.
- Refactor `_url_to_path()` to share a new `_safe_join()` helper so the read and write paths cannot drift apart.
- Add a contract note on the `StorageProvider` ABC: implementations MUST reject `filename` values that resolve outside their storage scope.
- Update `bnbagent/storage/README.md` accordingly.
- Add regression tests covering relative `..`, absolute paths, nested `a/../../`, symlink-based escape from inside base, and the `upload_sync` bridge.

## Why

`upload()` previously wrote to `self._base / fname` with no validation, while the read side (`_url_to_path`) already enforced the check. A caller supplying `filename="../escape.json"` or `filename="/etc/cron.d/x"` could write outside the configured directory. Since `bnbagent` is an agent SDK where `filename` can be influenced by external inputs (HTTP bodies, on-chain fields, agent tool calls), this is treated as untrusted.

## Supersedes #27

PR #27 targeted `bnbagent/storage/local_provider.py::save_sync()` — neither the file nor the method exist on `main`. The real vulnerable code is `bnbagent/storage/local_storage_provider.py::upload()`. This PR fixes the actual method, unifies read/write traversal checks via a shared helper, raises the contract to the ABC, and adds broader regression coverage (including symlink escape and the sync bridge).

## Test plan

- [x] `uv run pytest tests/test_local_storage.py -v` → 21/21 pass (5 new traversal cases + 16 existing).
- [x] `uv run pytest tests/ -q` → 371/371 pass, no regressions.
- [x] Caller audit: only live `.upload()` callsite is `bnbagent/erc8183/server/job_ops.py:215` with `f"erc8183-job-{job_id}.json"` where `job_id` is on-chain `uint256` — safe.
- [x] Diff scope verified: only 4 files (`local_storage_provider.py`, `storage_provider.py`, `storage/README.md`, `test_local_storage.py`).

## Follow-up (out of scope)

- A theoretical TOCTOU between `_safe_join()` and `write_text()` exists if an attacker can plant a symlink inside `_base` between the check and write. `_base` is created with `0700`, so this requires same-UID privilege (already game-over). A hardened fix would use `os.open(..., O_NOFOLLOW)`; not addressed here to keep the patch focused on the reported issue.