### PR TITLE
fix: estimate gas, retry transient job failures, structured error envelopes

### DIFF
--- a/bnbagent/core/contract_mixin.py
+++ b/bnbagent/core/contract_mixin.py
@@ -6,6 +6,8 @@ import logging
 import time
 from typing import Any
 
+from web3.exceptions import ContractLogicError
+
 from .nonce_manager import NonceManager
 
 logger = logging.getLogger(__name__)
@@ -19,6 +21,13 @@ RETRY_BASE_DELAY = 1.0
 # a safe minimum across BSC mainnet/testnet at the time of writing.
 MIN_GAS_PRICE_WEI = 3_000_000_000
 
+# Fallback gas limit used only when on-chain estimation is unavailable
+# (transport/RPC error, opaque revert data) or bypassed (skip_preflight).
+# Nodes require ``balance >= gas_limit * gasPrice`` upfront, so a blanket
+# 2M limit would demand ~0.007 BNB per tx while typical writes burn
+# 50-150k gas — estimation keeps the entry cost proportional to real usage.
+DEFAULT_GAS_FALLBACK = 2_000_000
+
 
 class ContractClientMixin:
     """Shared transaction sending and retry logic for web3 contract clients.
@@ -30,13 +39,21 @@ class ContractClientMixin:
     """
 
     def _send_tx(
-        self, fn, value: int = 0, gas: int = 2_000_000, skip_preflight: bool = False
+        self, fn, value: int = 0, gas: int | None = None, skip_preflight: bool = False
     ) -> dict[str, Any]:
-        """Build, sign, and send a transaction with nonce management and retry."""
+        """Build, sign, and send a transaction with nonce management and retry.
+
+        ``gas=None`` (default) estimates the limit on-chain with a 20% buffer
+        (mirroring erc8004's ``_execute_transaction``); pass an explicit ``gas``
+        to skip estimation.
+        """
         if not self._wallet_provider:
             raise RuntimeError(
                 "wallet_provider is required for write operations (client is read-only)"
             )
+
+        if gas is None:
+            gas = self._estimate_gas_limit(fn, value, skip_preflight)
 
         nonce_mgr = NonceManager.for_account(self.w3, self._account)
         last_error = None
@@ -134,6 +151,34 @@ class ContractClientMixin:
                 raise
 
         raise last_error  # type: ignore
+
+    def _estimate_gas_limit(self, fn, value: int, skip_preflight: bool) -> int:
+        """Estimate gas for ``fn`` with a 20% buffer.
+
+        Falls back to ``DEFAULT_GAS_FALLBACK`` when estimation is unavailable —
+        transport/RPC errors, or nodes returning opaque ``0x`` revert data (the
+        same escape hatch the pre-flight uses). A genuine revert surfaced by
+        the estimation is raised as ``Transaction would revert`` so the caller
+        sees the reason instead of a masked fallback broadcast.
+        """
+        class_name = type(self).__name__
+        if skip_preflight:
+            # estimate_gas simulates the call exactly like the pre-flight does;
+            # callers that opted out of simulation get the fallback limit.
+            return DEFAULT_GAS_FALLBACK
+        try:
+            estimate = fn.estimate_gas({"from": self._account, "value": value})
+            return int(estimate * 1.2)
+        except Exception as e:
+            err_str = str(e)
+            is_opaque = "'0x'" in err_str or err_str.strip().endswith(", '0x')")
+            if isinstance(e, ContractLogicError) and not is_opaque:
+                raise RuntimeError(f"Transaction would revert: {e}") from e
+            logger.warning(
+                f"[{class_name}] Gas estimation unavailable ({e}); "
+                f"falling back to gas={DEFAULT_GAS_FALLBACK}"
+            )
+            return DEFAULT_GAS_FALLBACK
 
     def _call_with_retry(self, fn):
         """Call a read function with retry on rate limit."""

--- a/bnbagent/erc8183/policy.py
+++ b/bnbagent/erc8183/policy.py
@@ -24,6 +24,7 @@ from web3 import Web3
 from web3.contract import Contract
 
 from ..core.contract_mixin import ContractClientMixin
+from ..exceptions import RpcRangeLimitError
 from ..wallets.wallet_provider import WalletProvider
 from .types import Verdict
 
@@ -98,6 +99,9 @@ class PolicyClient(ContractClientMixin):
         Reads the ``JobInitialised`` event emitted by ``onSubmitted`` and
         parses ``optParams`` (JSON bytes) to extract ``deliverable_url``.
         Returns ``None`` if the event is not found or the field is absent.
+        Raises :class:`~bnbagent.exceptions.RpcRangeLimitError` when the node
+        rejects the log query with a rate/range limit (``-32005``) — that is
+        retryable, not proof of absence.
 
         Prefer calling ``ERC8183Client.get_deliverable_url`` which auto-resolves
         ``hint_block`` via Commerce's ``JobSubmitted`` event.  If called directly
@@ -128,6 +132,15 @@ class PolicyClient(ContractClientMixin):
                 argument_filters={"jobId": job_id},
             )
         except Exception as exc:
+            err = str(exc)
+            if "-32005" in err or "limit exceeded" in err.lower():
+                # Rate/range-limited RPC is NOT "event not found" — surface a
+                # typed retryable error instead of a None the caller would
+                # misread as a genuinely absent deliverable.
+                raise RpcRangeLimitError(
+                    f"JobInitialised scan for job {job_id} hit the RPC "
+                    f"range/rate limit; retry later"
+                ) from exc
             logger.warning("[PolicyClient] get_deliverable_url(%s) event query failed: %s", job_id, exc)
             return None
 

--- a/bnbagent/erc8183/server/job_ops.py
+++ b/bnbagent/erc8183/server/job_ops.py
@@ -17,6 +17,7 @@ import asyncio
 import inspect
 import json
 import logging
+import re
 import time
 from collections.abc import Callable
 from typing import Any
@@ -25,6 +26,7 @@ from web3 import Web3
 
 from ...config import NetworkConfig
 from ...core.config import get_env
+from ...exceptions import RpcRangeLimitError
 from ...storage.storage_provider import StorageProvider
 from ...wallets.wallet_provider import WalletProvider
 from ..client import ERC8183Client
@@ -62,6 +64,43 @@ def _max_response_bytes() -> int:
 
 def _max_metadata_bytes() -> int:
     return _read_int_env("MAX_METADATA_BYTES", _DEFAULT_MAX_METADATA_BYTES)
+
+
+_TRANSIENT_ERROR_KEYWORDS = (
+    "timeout", "connection", "network", "rpc",
+    "429", "too many requests", "rate limit", "limit exceeded",
+)
+
+
+def _exc_error_fields(exc: Exception) -> dict[str, Any]:
+    """Safe ``{"error", "error_code"}`` fields for an exception.
+
+    web3 RPC errors carry ``{'code': ..., 'message': ...}`` whose ``str()``
+    is a Python dict-repr — surface the inner message instead so consumers
+    embedding ``error`` never produce nested, json-rejecting blobs.
+    Transport errors are replaced by a generic message and any URL-shaped
+    token is redacted (RPC endpoints embed API keys in the path); other
+    messages (e.g. revert reasons) pass through. ``error_code`` is
+    HTTP-like: 503 for transient chain/RPC trouble, 500 otherwise. The raw
+    JSON-RPC code (e.g. ``-32005``), when present, rides along separately
+    as ``rpc_error_code`` — never mixed into ``error_code``.
+    """
+    payload = exc.args[0] if exc.args else None
+    rpc_code = None
+    if isinstance(payload, dict) and "message" in payload:
+        message = str(payload["message"])
+        if isinstance(payload.get("code"), int):
+            rpc_code = payload["code"]
+    else:
+        message = str(exc)
+    if any(k in message.lower() for k in _TRANSIENT_ERROR_KEYWORDS):
+        fields = {"error": "Temporary chain/RPC error", "error_code": 503}
+    else:
+        message = re.sub(r"\S+://\S+", "<redacted>", message)
+        fields = {"error": message, "error_code": 500}
+    if rpc_code is not None:
+        fields["rpc_error_code"] = rpc_code
+    return fields
 
 
 class ERC8183JobOps:
@@ -173,6 +212,7 @@ class ERC8183JobOps:
                 return {
                     "success": False,
                     "error": f"Job verification failed: {verification.get('error', 'unknown')}",
+                    "error_code": verification.get("error_code"),
                 }
 
             max_resp = _max_response_bytes()
@@ -242,7 +282,7 @@ class ERC8183JobOps:
             }
         except Exception as exc:
             logger.error(f"[ERC8183JobOps] submit({job_id}) failed: {exc}")
-            return {"success": False, "error": str(exc)}
+            return {"success": False, **_exc_error_fields(exc)}
 
     # ------------------------------------------------------------------ reads
 
@@ -312,10 +352,39 @@ class ERC8183JobOps:
                 self._deliverable_urls[job_id] = deliverable_url
                 data = await self._storage.download(deliverable_url)
                 return {"success": True, **data}
+        except RpcRangeLimitError as exc:
+            logger.warning(f"[ERC8183JobOps] get_response({job_id}) rate-limited: {exc}")
+            return {
+                "success": False,
+                "error": (
+                    f"Deliverable for job {job_id} temporarily unresolvable "
+                    "(RPC rate limit); retry"
+                ),
+                "error_code": 503,
+            }
         except Exception as exc:
             logger.warning(f"[ERC8183JobOps] get_response({job_id}) on-chain fallback failed: {exc}")
 
-        return {"success": False, "error": f"Response not found for job {job_id}"}
+        # A job that has been submitted on-chain MUST have a JobInitialised
+        # event, so failing to resolve its URL above (rate-limited RPC,
+        # submit older than the fallback scan window, storage hiccup) is a
+        # resolution failure — retryable, not proof of absence. Only a job
+        # that never reached SUBMITTED genuinely has no response.
+        status_result = await self.get_job_status(job_id)
+        if not status_result.get("success") or status_result.get("status") in (
+            JobStatus.SUBMITTED,
+            JobStatus.COMPLETED,
+        ):
+            return {
+                "success": False,
+                "error": f"Deliverable for job {job_id} temporarily unresolvable; retry",
+                "error_code": 503,
+            }
+        return {
+            "success": False,
+            "error": f"Response not found for job {job_id}",
+            "error_code": 404,
+        }
 
     # ---------------------------------------------------- verification helper
 
@@ -494,7 +563,7 @@ class ERC8183JobOps:
         except Exception as exc:
             logger.warning(f"[ERC8183JobOps] startup scan counter failed: {exc}")
             self._startup_scan_done = True
-            return {"success": False, "error": str(exc), "jobs": []}
+            return {"success": False, **_exc_error_fields(exc), "jobs": []}
 
         if counter == 0:
             self._startup_scan_done = True
@@ -529,7 +598,7 @@ class ERC8183JobOps:
             return result
         except Exception as exc:
             logger.error(f"[ERC8183JobOps] get_pending_jobs failed: {exc}")
-            return {"success": False, "error": str(exc), "jobs": []}
+            return {"success": False, **_exc_error_fields(exc), "jobs": []}
 
     async def get_submitted_jobs(self) -> dict[str, Any]:
         """Return SUBMITTED jobs assigned to this provider (opt-in auto-settle).
@@ -571,7 +640,7 @@ class ERC8183JobOps:
             return {"success": True, "jobs": submitted}
         except Exception as exc:
             logger.error(f"[ERC8183JobOps] get_submitted_jobs failed: {exc}")
-            return {"success": False, "error": "Failed to scan submitted jobs", "jobs": []}
+            return {"success": False, **_exc_error_fields(exc), "jobs": []}
 
 
 async def funded_job_watcher(
@@ -585,31 +654,63 @@ async def funded_job_watcher(
 
     Signer-free detection loop for keyless services: it NEVER submits or settles
     — the caller decides what to do (e.g. delegate signing to a separate Agent).
-    ``on_funded`` may be sync or async. Each job id fires at most once (a keyless
-    service does not transition the job out of FUNDED, so dedup prevents repeat
-    triggers). Pass an ``asyncio.Event`` as ``stop`` to end the loop; otherwise
-    it runs until cancelled.
+    ``on_funded`` may be sync or async.
+
+    Retry contract: a job fires once on success. ``on_funded`` raising, or
+    returning ``False`` / ``{"retry": True}``, marks the job for retry on the
+    next tick (after re-checking on-chain that it is still FUNDED and
+    unexpired — ``get_pending_jobs`` reports each job only once, so retries
+    are re-validated via ``get_job``). Retries stop naturally when the job
+    leaves FUNDED or expires. Any other return value (incl. ``None``) keeps
+    fire-once behavior. Pass an ``asyncio.Event`` as ``stop`` to end the
+    loop; otherwise it runs until cancelled.
     """
     seen: set[int] = set()
+    retry: set[int] = set()
     is_async = inspect.iscoroutinefunction(on_funded)
+
+    async def _fire(job: dict[str, Any]) -> None:
+        job_id = job["jobId"]
+        try:
+            if is_async:
+                result = await on_funded(job)
+            else:
+                result = await asyncio.to_thread(on_funded, job)
+        except Exception as exc:
+            logger.error(
+                "[funded_job_watcher] on_funded(%s) failed; will retry: %s",
+                job_id, exc,
+            )
+            retry.add(job_id)
+            return
+        if result is False or (isinstance(result, dict) and result.get("retry")):
+            retry.add(job_id)
+        else:
+            retry.discard(job_id)
+            seen.add(job_id)
+
     while True:
         try:
+            # Re-validate + re-fire previously failed jobs first, so a job
+            # failing below is not retried within the same tick.
+            for job_id in list(retry):
+                fresh = await job_ops.get_job(job_id)
+                if not fresh.get("success"):
+                    continue  # transient read error — keep for next tick
+                if (
+                    fresh.get("status") != JobStatus.FUNDED
+                    or fresh.get("expiredAt", 0) <= int(time.time())
+                ):
+                    retry.discard(job_id)  # job moved on — stop retrying
+                    continue
+                await _fire(fresh)
+
             result = await job_ops.get_pending_jobs()
             if result.get("success"):
                 for job in result.get("jobs", []):
-                    job_id = job["jobId"]
-                    if job_id in seen:
+                    if job["jobId"] in seen or job["jobId"] in retry:
                         continue
-                    seen.add(job_id)
-                    try:
-                        if is_async:
-                            await on_funded(job)
-                        else:
-                            await asyncio.to_thread(on_funded, job)
-                    except Exception as exc:
-                        logger.error(
-                            "[funded_job_watcher] on_funded(%s) failed: %s", job_id, exc
-                        )
+                    await _fire(job)
             else:
                 logger.warning(
                     "[funded_job_watcher] poll error: %s", result.get("error")

--- a/bnbagent/erc8183/server/routes.py
+++ b/bnbagent/erc8183/server/routes.py
@@ -31,6 +31,11 @@ from .rate_limit import SlidingWindowLimiter
 
 logger = logging.getLogger(__name__)
 
+# Ceiling on transient-failure retries per job in the funded poll loop.
+# Each attempt re-runs the (potentially expensive) on_job handler, so
+# retries are bounded instead of running until the job expires.
+_MAX_JOB_ATTEMPTS = 5
+
 
 @dataclass
 class ERC8183State:
@@ -161,7 +166,9 @@ def _create_erc8183_routes(state: ERC8183State) -> APIRouter:
     async def get_job_response(job_id: int):
         result = await state.job_ops.get_response(job_id)
         if not result.get("success"):
-            return JSONResponse(result, status_code=404)
+            # get_response distinguishes "no response exists" (404) from
+            # "deliverable exists but temporarily unresolvable" (503).
+            return JSONResponse(result, status_code=result.get("error_code") or 404)
         return JSONResponse(result)
 
     @router.get("/job/{job_id}/verify")
@@ -273,7 +280,7 @@ def create_erc8183_app(
                         await asyncio.to_thread(on_job_skipped, target, reason)
                 except Exception as exc:
                     logger.error(f"[ERC-8183] on_job_skipped callback error: {exc}")
-            return {"success": False, "error": reason}
+            return {"success": False, "error": reason, "error_code": error_code}
 
         job = verification["job"]
 
@@ -303,6 +310,47 @@ def create_erc8183_app(
             logger.error(f"[ERC-8183] Job #{job_id} submission failed: {submission.get('error')}")
         return submission
 
+    # Transiently-failed jobs queued for retry: job_id -> failed attempts so
+    # far. get_pending_jobs reports each FUNDED job only once (cursor-based),
+    # so a job that fails here would otherwise be lost until process restart.
+    retry_attempts: dict[int, int] = {}
+
+    async def _attempt_job(job_id: int) -> None:
+        if job_id in processing_jobs:
+            return
+        processing_jobs.add(job_id)
+        try:
+            submission = await _execute_job_internal(job_id)
+            if submission.get("success"):
+                retry_attempts.pop(job_id, None)
+                return
+            code = submission.get("error_code")
+            if isinstance(code, int) and 400 <= code < 500:
+                # Permanent (not provider, expired, under-priced, oversize,
+                # no longer FUNDED, ...) — retrying cannot succeed.
+                retry_attempts.pop(job_id, None)
+                return
+            _schedule_retry(job_id, submission.get("error"))
+        except Exception as exc:
+            logger.error(f"[ERC-8183] Funded-poll job #{job_id} failed: {exc}")
+            _schedule_retry(job_id, exc)
+        finally:
+            processing_jobs.discard(job_id)
+
+    def _schedule_retry(job_id: int, reason) -> None:
+        attempts = retry_attempts.get(job_id, 0) + 1
+        if attempts >= _MAX_JOB_ATTEMPTS:
+            retry_attempts.pop(job_id, None)
+            logger.error(
+                f"[ERC-8183] Job #{job_id} giving up after {attempts} attempts: {reason}"
+            )
+            return
+        retry_attempts[job_id] = attempts
+        logger.warning(
+            f"[ERC-8183] Job #{job_id} attempt {attempts}/{_MAX_JOB_ATTEMPTS} failed; "
+            f"will retry next poll: {reason}"
+        )
+
     async def _funded_poll_loop():
         logger.info(
             f"[ERC-8183] Funded-job poll loop starting (interval={effective_poll_interval:.1f}s)"
@@ -310,6 +358,12 @@ def create_erc8183_app(
         try:
             while True:
                 try:
+                    # Retries first, so a job failing below is not re-attempted
+                    # within the same tick. _execute_job_internal re-verifies,
+                    # dropping jobs that left FUNDED with a permanent 4xx.
+                    for job_id in list(retry_attempts):
+                        await _attempt_job(job_id)
+
                     result = await state.job_ops.get_pending_jobs()
                     if result.get("success"):
                         jobs = result.get("jobs", [])
@@ -318,18 +372,7 @@ def create_erc8183_app(
                                 f"[ERC-8183] Funded-poll picked up {len(jobs)} pending job(s)"
                             )
                         for job in jobs:
-                            job_id = job["jobId"]
-                            if job_id in processing_jobs:
-                                continue
-                            processing_jobs.add(job_id)
-                            try:
-                                await _execute_job_internal(job_id)
-                            except Exception as exc:
-                                logger.error(
-                                    f"[ERC-8183] Funded-poll job #{job_id} failed: {exc}"
-                                )
-                            finally:
-                                processing_jobs.discard(job_id)
+                            await _attempt_job(job["jobId"])
                     else:
                         logger.warning(
                             f"[ERC-8183] Funded-poll error: {result.get('error')}"

--- a/bnbagent/exceptions.py
+++ b/bnbagent/exceptions.py
@@ -78,6 +78,18 @@ class NetworkError(BNBAgentError):
     pass
 
 
+class RpcRangeLimitError(NetworkError):
+    """
+    An RPC log/range query was rejected by the node's rate or range limit
+    (e.g. JSON-RPC ``-32005 limit exceeded``).
+
+    Retryable: the queried data may exist but could not be fetched right
+    now — callers must NOT treat this as "event not found".
+    """
+
+    pass
+
+
 class JobError(BNBAgentError):
     """
     Job operation failed.

--- a/tests/test_contract_mixin.py
+++ b/tests/test_contract_mixin.py
@@ -1,0 +1,106 @@
+"""Tests for ContractClientMixin._send_tx gas-limit estimation.
+
+A hardcoded 2M gas limit makes nodes demand ``balance >= 2M * gasPrice``
+(~0.007 BNB) upfront while typical writes burn 50-150k gas. ``gas=None``
+now estimates on-chain with a 20% buffer (mirroring erc8004) and only
+falls back to ``DEFAULT_GAS_FALLBACK`` when estimation is unavailable.
+"""
+
+from unittest.mock import MagicMock
+
+import pytest
+from web3.exceptions import ContractLogicError
+
+from bnbagent.core.contract_mixin import DEFAULT_GAS_FALLBACK, ContractClientMixin
+from bnbagent.core.nonce_manager import NonceManager
+from tests.conftest import FAKE_ADDRESS
+
+
+class _FakeClient(ContractClientMixin):
+    def __init__(self, w3, wallet_provider):
+        self.w3 = w3
+        self._wallet_provider = wallet_provider
+        self._account = FAKE_ADDRESS
+
+
+@pytest.fixture(autouse=True)
+def _clear_nonce_singletons():
+    NonceManager._clear_all()
+    yield
+    NonceManager._clear_all()
+
+
+@pytest.fixture
+def client(mock_web3):
+    wallet = MagicMock()
+    wallet.address = FAKE_ADDRESS
+    wallet.sign_transaction.return_value = {"rawTransaction": b"\x00" * 32}
+    return _FakeClient(mock_web3, wallet)
+
+
+def _make_fn(estimate=100_000):
+    fn = MagicMock()
+    fn.estimate_gas.return_value = estimate
+    fn.build_transaction.side_effect = lambda params: {
+        **params,
+        "to": "0x" + "11" * 20,
+        "data": "0x",
+    }
+    return fn
+
+
+def _built_gas(fn) -> int:
+    return fn.build_transaction.call_args[0][0]["gas"]
+
+
+class TestGasEstimation:
+    def test_estimates_with_20pct_buffer(self, client):
+        fn = _make_fn(estimate=100_000)
+        result = client._send_tx(fn)
+        assert result["status"] == 1
+        fn.estimate_gas.assert_called_once_with({"from": FAKE_ADDRESS, "value": 0})
+        assert _built_gas(fn) == 120_000
+
+    def test_estimate_includes_value(self, client):
+        fn = _make_fn()
+        client._send_tx(fn, value=123)
+        fn.estimate_gas.assert_called_once_with({"from": FAKE_ADDRESS, "value": 123})
+
+    def test_explicit_gas_skips_estimation(self, client):
+        fn = _make_fn()
+        client._send_tx(fn, gas=500_000)
+        fn.estimate_gas.assert_not_called()
+        assert _built_gas(fn) == 500_000
+
+    def test_transport_error_falls_back_to_default(self, client):
+        fn = _make_fn()
+        fn.estimate_gas.side_effect = ConnectionError("rpc down")
+        result = client._send_tx(fn)
+        assert result["status"] == 1
+        assert _built_gas(fn) == DEFAULT_GAS_FALLBACK
+
+    def test_genuine_revert_propagates(self, client):
+        fn = _make_fn()
+        fn.estimate_gas.side_effect = ContractLogicError(
+            "execution reverted: NotProvider"
+        )
+        with pytest.raises(RuntimeError, match="Transaction would revert"):
+            client._send_tx(fn)
+        fn.build_transaction.assert_not_called()
+
+    def test_opaque_revert_falls_back_to_default(self, client):
+        # Some nodes return no revert data; str() of the error ends with
+        # ", '0x')" — the same escape hatch the pre-flight uses.
+        fn = _make_fn()
+        fn.estimate_gas.side_effect = ContractLogicError(
+            ("execution reverted", "0x")
+        )
+        result = client._send_tx(fn)
+        assert result["status"] == 1
+        assert _built_gas(fn) == DEFAULT_GAS_FALLBACK
+
+    def test_skip_preflight_skips_estimation(self, client):
+        fn = _make_fn()
+        client._send_tx(fn, skip_preflight=True)
+        fn.estimate_gas.assert_not_called()
+        assert _built_gas(fn) == DEFAULT_GAS_FALLBACK

--- a/tests/test_erc8183_client.py
+++ b/tests/test_erc8183_client.py
@@ -260,3 +260,36 @@ class TestReads:
         facade.policy.check.return_value = (Verdict.APPROVE, b"\x00" * 32)
         verdict, _ = facade.get_verdict(1)
         assert verdict == Verdict.APPROVE
+
+
+class TestPolicyRangeLimit:
+    """Rate/range-limited log queries raise typed retryable errors (BUG-06)."""
+
+    def _policy(self):
+        from bnbagent.erc8183.policy import PolicyClient
+
+        w3 = MagicMock()
+        w3.eth.block_number = 5000
+        return PolicyClient(w3, "0x" + "f8" * 20, abi=[])
+
+    def test_rate_limit_raises_typed_error(self):
+        from bnbagent.exceptions import RpcRangeLimitError
+
+        policy = self._policy()
+        policy.contract.events.JobInitialised.return_value.get_logs.side_effect = (
+            Exception("{'code': -32005, 'message': 'limit exceeded'}")
+        )
+        with pytest.raises(RpcRangeLimitError):
+            policy.get_deliverable_url(1)
+
+    def test_other_query_error_still_returns_none(self):
+        policy = self._policy()
+        policy.contract.events.JobInitialised.return_value.get_logs.side_effect = (
+            Exception("some other rpc problem")
+        )
+        assert policy.get_deliverable_url(1) is None
+
+    def test_genuine_empty_returns_none(self):
+        policy = self._policy()
+        policy.contract.events.JobInitialised.return_value.get_logs.return_value = []
+        assert policy.get_deliverable_url(1) is None

--- a/tests/test_erc8183_job_ops.py
+++ b/tests/test_erc8183_job_ops.py
@@ -439,6 +439,18 @@ class TestGetSubmittedJobs:
         assert ids == [1]
         assert result["jobs"][0]["submittedAt"] == 111
 
+    @pytest.mark.asyncio
+    async def test_scan_error_carries_structured_envelope(self):
+        ops = ERC8183JobOps(provider_address=ME)
+        client = _inject_client(ops)
+        client.commerce.job_counter.side_effect = ValueError(
+            {"code": -32005, "message": "limit exceeded"}
+        )
+        result = await ops.get_submitted_jobs()
+        assert result["success"] is False
+        assert result["error_code"] == 503
+        assert result["rpc_error_code"] == -32005
+
 
 class TestDecodeJob:
     """submittedAt (getJob tuple index 9) is surfaced on Job."""
@@ -461,3 +473,224 @@ class TestDecodeJob:
         assert job.submitted_at == 1500
         assert job.expired_at == 2000
         assert job.status == JobStatus.SUBMITTED
+
+
+class TestFundedJobWatcherRetry:
+    """Failed callbacks re-fire after on-chain re-validation (BUG-04).
+
+    ``get_pending_jobs`` reports each FUNDED job only once (cursor-based),
+    so the watcher re-validates retry candidates via ``get_job``.
+    """
+
+    def _ops_with_one_poll(self, job):
+        ops = ERC8183JobOps(provider_address=ME)
+        polls = [{"success": True, "jobs": [job]}]
+
+        async def get_pending_jobs():
+            return polls.pop(0) if polls else {"success": True, "jobs": []}
+
+        ops.get_pending_jobs = get_pending_jobs
+        return ops
+
+    @staticmethod
+    def _fresh(status=JobStatus.FUNDED):
+        return {
+            "success": True,
+            "jobId": 1,
+            "provider": ME,
+            "status": status,
+            "expiredAt": int(time.time()) + 3600,
+        }
+
+    @pytest.mark.asyncio
+    async def test_raising_callback_refires_after_revalidation(self):
+        ops = self._ops_with_one_poll({"jobId": 1, "provider": ME})
+        ops.get_job = AsyncMock(return_value=self._fresh())
+
+        calls: list[int] = []
+        stop = asyncio.Event()
+
+        async def on_funded(job):
+            calls.append(job["jobId"])
+            if len(calls) == 1:
+                raise RuntimeError("transient boom")
+            stop.set()
+
+        await funded_job_watcher(ops, on_funded, interval=0.01, stop=stop)
+        assert calls == [1, 1]
+
+    @pytest.mark.asyncio
+    async def test_false_return_opts_into_retry(self):
+        ops = self._ops_with_one_poll({"jobId": 1, "provider": ME})
+        ops.get_job = AsyncMock(return_value=self._fresh())
+
+        calls: list[int] = []
+        stop = asyncio.Event()
+
+        async def on_funded(job):
+            calls.append(job["jobId"])
+            if len(calls) == 1:
+                return False
+            stop.set()
+
+        await funded_job_watcher(ops, on_funded, interval=0.01, stop=stop)
+        assert calls == [1, 1]
+
+    @pytest.mark.asyncio
+    async def test_none_return_keeps_fire_once_compat(self):
+        ops = ERC8183JobOps(provider_address=ME)
+        stop = asyncio.Event()
+        poll_count = 0
+
+        async def get_pending_jobs():
+            nonlocal poll_count
+            poll_count += 1
+            if poll_count >= 3:
+                stop.set()
+            return {"success": True, "jobs": [{"jobId": 1, "provider": ME}]}
+
+        ops.get_pending_jobs = get_pending_jobs
+        calls: list[int] = []
+
+        async def on_funded(job):
+            calls.append(job["jobId"])
+
+        await funded_job_watcher(ops, on_funded, interval=0.01, stop=stop)
+        assert calls == [1]
+
+    @pytest.mark.asyncio
+    async def test_retry_dropped_when_job_leaves_funded(self):
+        ops = self._ops_with_one_poll({"jobId": 1, "provider": ME})
+        stop = asyncio.Event()
+
+        async def get_job(job_id):
+            stop.set()
+            return self._fresh(status=JobStatus.SUBMITTED)
+
+        ops.get_job = get_job
+        calls: list[int] = []
+
+        async def on_funded(job):
+            calls.append(job["jobId"])
+            raise RuntimeError("boom")
+
+        await funded_job_watcher(ops, on_funded, interval=0.01, stop=stop)
+        assert calls == [1]
+
+
+class TestExcErrorFields:
+    """Error envelopes never embed dict-reprs or RPC URLs (BUG-09)."""
+
+    def test_web3_dict_error_surfaces_inner_message(self):
+        from bnbagent.erc8183.server.job_ops import _exc_error_fields
+
+        exc = ValueError({"code": -32000, "message": "insufficient funds for gas"})
+        fields = _exc_error_fields(exc)
+        assert fields["error"] == "insufficient funds for gas"
+        assert fields["error_code"] == 500
+        assert fields["rpc_error_code"] == -32000
+
+    def test_rate_limited_rpc_is_503(self):
+        from bnbagent.erc8183.server.job_ops import _exc_error_fields
+
+        exc = ValueError({"code": -32005, "message": "limit exceeded"})
+        fields = _exc_error_fields(exc)
+        assert fields["error_code"] == 503
+        assert fields["rpc_error_code"] == -32005
+
+    def test_transport_error_does_not_leak_url(self):
+        from bnbagent.erc8183.server.job_ops import _exc_error_fields
+
+        exc = ConnectionError(
+            "HTTPSConnectionPool(host='rpc.example.com'): Max retries exceeded "
+            "with url: /v1/SECRETKEY"
+        )
+        fields = _exc_error_fields(exc)
+        assert "SECRETKEY" not in fields["error"]
+        assert fields["error_code"] == 503
+
+    def test_revert_reason_passes_through(self):
+        from bnbagent.erc8183.server.job_ops import _exc_error_fields
+
+        exc = RuntimeError("Transaction would revert: NotProvider")
+        fields = _exc_error_fields(exc)
+        assert fields["error"] == "Transaction would revert: NotProvider"
+        assert fields["error_code"] == 500
+
+    def test_non_transient_url_is_redacted_not_replaced(self):
+        from bnbagent.erc8183.server.job_ops import _exc_error_fields
+
+        exc = RuntimeError(
+            "Cannot publish: ERC8183_AGENT_URL is not set "
+            "(e.g. http://localhost:8003/erc8183)"
+        )
+        fields = _exc_error_fields(exc)
+        assert "ERC8183_AGENT_URL" in fields["error"]
+        assert "localhost" not in fields["error"]
+
+    @pytest.mark.asyncio
+    async def test_submit_result_verify_failure_propagates_error_code(self):
+        ops = _make_ops()
+        ops.verify_job = AsyncMock(
+            return_value={
+                "valid": False,
+                "error": "Job status is SUBMITTED, expected FUNDED",
+                "error_code": 409,
+            }
+        )
+        result = await ops.submit_result(1, "content")
+        assert result["success"] is False
+        assert result["error_code"] == 409
+
+
+class TestGetResponseClassification:
+    """Unresolvable deliverable for a submitted job is 503, not 404 (BUG-06)."""
+
+    def _ops(self, status_result):
+        storage = MagicMock(spec=["download", "upload"])
+        ops = _make_ops(storage=storage)
+        client = _inject_client(ops)
+        client.get_deliverable_url.return_value = None
+        ops.get_job = AsyncMock(return_value=status_result)
+        return ops
+
+    @pytest.mark.asyncio
+    async def test_submitted_job_unresolvable_is_503(self):
+        ops = self._ops({"success": True, "status": JobStatus.SUBMITTED})
+        result = await ops.get_response(1)
+        assert result["success"] is False
+        assert result["error_code"] == 503
+
+    @pytest.mark.asyncio
+    async def test_completed_job_unresolvable_is_503(self):
+        ops = self._ops({"success": True, "status": JobStatus.COMPLETED})
+        result = await ops.get_response(1)
+        assert result["error_code"] == 503
+
+    @pytest.mark.asyncio
+    async def test_never_submitted_job_is_genuine_404(self):
+        ops = self._ops({"success": True, "status": JobStatus.FUNDED})
+        result = await ops.get_response(1)
+        assert result["error_code"] == 404
+
+    @pytest.mark.asyncio
+    async def test_unknown_status_is_503(self):
+        ops = self._ops(
+            {"success": False, "error": "Temporary chain/RPC error", "error_code": 503}
+        )
+        result = await ops.get_response(1)
+        assert result["error_code"] == 503
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_resolution_is_503_without_status_lookup(self):
+        from bnbagent.exceptions import RpcRangeLimitError
+
+        storage = MagicMock(spec=["download", "upload"])
+        ops = _make_ops(storage=storage)
+        client = _inject_client(ops)
+        client.get_deliverable_url.side_effect = RpcRangeLimitError("limit exceeded")
+        ops.get_job = AsyncMock()
+        result = await ops.get_response(1)
+        assert result["success"] is False
+        assert result["error_code"] == 503
+        ops.get_job.assert_not_called()

--- a/tests/test_erc8183_routes_poll.py
+++ b/tests/test_erc8183_routes_poll.py
@@ -1,0 +1,143 @@
+"""Funded poll loop retry behavior — transient failures retry, permanent don't.
+
+``get_pending_jobs`` reports each FUNDED job only once (cursor-based), so a
+job whose execution fails transiently (5xx / exception) must be re-attempted
+from the loop's retry queue; permanent failures (4xx) must not retry.
+"""
+
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+from fastapi.testclient import TestClient
+
+from bnbagent.erc8183.server.routes import create_erc8183_app
+
+
+def _fake_state(job_ops):
+    state = MagicMock()
+    state.job_ops = job_ops
+    state.payment_token = ""
+    state.payment_token_decimals = 18
+    return state
+
+
+def _job_ops(verify_results, pending_jobs):
+    """JobOps stub: one funded poll returning ``pending_jobs``, then empty."""
+    polls = [{"success": True, "jobs": list(pending_jobs)}]
+
+    async def get_pending_jobs():
+        return polls.pop(0) if polls else {"success": True, "jobs": []}
+
+    ops = MagicMock()
+    ops.agent_address = "0x" + "aa" * 20
+    ops.get_pending_jobs = get_pending_jobs
+    ops.verify_job = AsyncMock(side_effect=verify_results)
+    ops.submit_result = AsyncMock(
+        return_value={"success": True, "txHash": "0x" + "de" * 32}
+    )
+    return ops
+
+
+def _run_app(ops, on_job, seconds=1.0, until=None):
+    app = create_erc8183_app(
+        config=MagicMock(),
+        on_job=on_job,
+        funded_poll_interval=0.02,
+    )
+    with TestClient(app):
+        deadline = time.time() + seconds
+        while time.time() < deadline:
+            if until is not None and until():
+                break
+            time.sleep(0.01)
+
+
+def _valid(job_id=1):
+    return {
+        "valid": True,
+        "job": {"jobId": job_id, "description": "", "budget": 1},
+        "warnings": None,
+    }
+
+
+class TestFundedPollRetry:
+    def test_transient_verify_failure_retries_then_succeeds(self, monkeypatch):
+        transient = {"valid": False, "error": "Temporary chain/RPC error", "error_code": 503}
+        ops = _job_ops(
+            verify_results=[transient, _valid()],
+            pending_jobs=[{"jobId": 1}],
+        )
+        monkeypatch.setattr(
+            "bnbagent.erc8183.server.routes.create_erc8183_state",
+            lambda config: _fake_state(ops),
+        )
+        _run_app(
+            ops,
+            on_job=lambda job: "answer",
+            until=lambda: ops.submit_result.await_count >= 1,
+        )
+        assert ops.verify_job.await_count == 2
+        assert ops.submit_result.await_count == 1
+
+    def test_permanent_failure_does_not_retry(self, monkeypatch):
+        permanent = {"valid": False, "error": "This agent is not the provider", "error_code": 403}
+        ops = _job_ops(
+            verify_results=lambda job_id: permanent,
+            pending_jobs=[{"jobId": 1}],
+        )
+        monkeypatch.setattr(
+            "bnbagent.erc8183.server.routes.create_erc8183_state",
+            lambda config: _fake_state(ops),
+        )
+        _run_app(ops, on_job=lambda job: "answer", seconds=0.3)
+        assert ops.verify_job.await_count == 1
+        ops.submit_result.assert_not_called()
+
+    def test_retries_are_capped(self, monkeypatch):
+        transient = {"valid": False, "error": "Temporary chain/RPC error", "error_code": 503}
+        ops = _job_ops(
+            verify_results=lambda job_id: transient,
+            pending_jobs=[{"jobId": 1}],
+        )
+        monkeypatch.setattr(
+            "bnbagent.erc8183.server.routes.create_erc8183_state",
+            lambda config: _fake_state(ops),
+        )
+        _run_app(ops, on_job=lambda job: "answer", seconds=0.8)
+        # _MAX_JOB_ATTEMPTS = 5: initial attempt + 4 retries, then give up.
+        assert ops.verify_job.await_count == 5
+        ops.submit_result.assert_not_called()
+
+
+class TestResponseRoute:
+    """/response forwards get_response's error_code (503 vs 404), BUG-06."""
+
+    def _http(self, get_response_result, monkeypatch):
+        ops = MagicMock()
+        ops.agent_address = "0x" + "aa" * 20
+        ops.get_response = AsyncMock(return_value=get_response_result)
+        monkeypatch.setattr(
+            "bnbagent.erc8183.server.routes.create_erc8183_state",
+            lambda config: _fake_state(ops),
+        )
+        return TestClient(create_erc8183_app(config=MagicMock()))
+
+    def test_unresolvable_deliverable_forwards_503(self, monkeypatch):
+        http = self._http(
+            {"success": False, "error": "temporarily unresolvable", "error_code": 503},
+            monkeypatch,
+        )
+        assert http.get("/erc8183/job/1/response").status_code == 503
+
+    def test_genuine_not_found_is_404(self, monkeypatch):
+        http = self._http(
+            {"success": False, "error": "Response not found", "error_code": 404},
+            monkeypatch,
+        )
+        assert http.get("/erc8183/job/1/response").status_code == 404
+
+    def test_missing_error_code_defaults_to_404(self, monkeypatch):
+        http = self._http(
+            {"success": False, "error": "No storage configured"}, monkeypatch
+        )
+        assert http.get("/erc8183/job/1/response").status_code == 404


### PR DESCRIPTION
## What

- **Gas estimation**: `_send_tx` now estimates gas on-chain with a 1.2x buffer instead of a hardcoded 2M limit, cutting the upfront wallet balance requirement (~0.007 BNB -> ~0.0004 BNB for typical writes) and adapting to calldata size (long descriptions / optParams). Falls back to 2M only when estimation is unavailable; genuine reverts propagate with their reason.
- **Funded-job retry**: a transiently failing job is no longer permanently skipped until process restart. `funded_job_watcher` re-fires failed callbacks after re-validating the job is still FUNDED and unexpired (callbacks can also opt in via `False` / `{"retry": True}`); the server poll loop retries 5xx/exception failures with a 5-attempt cap and drops permanent 4xx failures.
- **Structured error envelopes**: failure dicts surface the inner web3 message plus an HTTP-like `error_code` (503 transient / 500 otherwise), carry the raw JSON-RPC code separately as `rpc_error_code`, redact URLs (RPC endpoints embed API keys), and never embed dict-reprs. Verification failures propagate their `error_code`.
- **Deliverable resolution**: rate/range-limited log queries raise a typed `RpcRangeLimitError` and surface as retryable 503 instead of a misleading 404; `get_response` additionally classifies by job status (submitted job with unresolvable URL = 503, never-submitted = 404), and the `/response` route forwards the `error_code`.

## Tests

28 new tests (gas estimation, watcher retry contract, poll-loop retry classification, error envelopes, 503/404 classification, route forwarding). Full suite: 500 passed.