### PR TITLE
test(erc8183): mock intent seam for router/policy write ops

### DIFF
--- a/tests/test_erc8183_policy.py
+++ b/tests/test_erc8183_policy.py
@@ -15,22 +15,23 @@ def policy_client(mock_web3):
     with patch("bnbagent.erc8183.policy._load_abi", return_value=[{"type": "function", "name": "dispute"}]):
         client = PolicyClient(mock_web3, "0x" + "11" * 20, wallet)
         client._send_tx = MagicMock()
+        client._execute_intent = MagicMock()
         client._call_with_retry = MagicMock()
         yield client
 
 
 class TestPolicyClient:
     def test_dispute(self, policy_client):
-        policy_client._send_tx.return_value = {"status": 1}
+        policy_client._execute_intent.return_value = {"status": 1}
         res = policy_client.dispute(1)
         assert res == {"status": 1}
-        policy_client._send_tx.assert_called_once()
+        policy_client._execute_intent.assert_called_once()
 
     def test_vote_reject(self, policy_client):
-        policy_client._send_tx.return_value = {"status": 1}
+        policy_client._execute_intent.return_value = {"status": 1}
         res = policy_client.vote_reject(1)
         assert res == {"status": 1}
-        policy_client._send_tx.assert_called_once()
+        policy_client._execute_intent.assert_called_once()
 
     def test_check(self, policy_client):
         policy_client._call_with_retry.return_value = (1, b"reason")

--- a/tests/test_erc8183_router.py
+++ b/tests/test_erc8183_router.py
@@ -13,22 +13,22 @@ def router_client(mock_web3):
     wallet.address = "0x" + "aa" * 20
     with patch("bnbagent.erc8183.router._load_abi", return_value=[{"type": "function", "name": "settle"}]):
         client = RouterClient(mock_web3, "0x" + "11" * 20, wallet)
-        client._send_tx = MagicMock()
+        client._execute_intent = MagicMock()
         client._call_with_retry = MagicMock()
         yield client
 
 
 class TestRouterClient:
     def test_register_job(self, router_client):
-        router_client._send_tx.return_value = {"status": 1}
+        router_client._execute_intent.return_value = {"status": 1}
         assert router_client.register_job(1, "0x" + "22" * 20) == {"status": 1}
 
     def test_settle(self, router_client):
-        router_client._send_tx.return_value = {"status": 1}
+        router_client._execute_intent.return_value = {"status": 1}
         assert router_client.settle(1, b"evidence") == {"status": 1}
 
     def test_mark_expired(self, router_client):
-        router_client._send_tx.return_value = {"status": 1}
+        router_client._execute_intent.return_value = {"status": 1}
         assert router_client.mark_expired(1) == {"status": 1}
 
     def test_commerce(self, router_client):


### PR DESCRIPTION
## Problem

CI `Run tests` failed with 5 failures (exit code 1) — [run 28504684411](https://github.com/bnb-chain/bnbagent-sdk/actions/runs/28504684411/job/84490118383):

```
AssertionError: assert <MagicMock name='mock.make_executor().execute()' ...> == {'status': 1}
```

- `test_erc8183_router.py::TestRouterClient`: `test_register_job`, `test_settle`, `test_mark_expired`
- `test_erc8183_policy.py::TestPolicyClient`: `test_dispute`, `test_vote_reject`

## Root cause

#44 migrated Router/Policy write ops from `self._send_tx(fn)` to the intent seam (`_execute_intent → make_executor().execute()`), but these unit tests still stubbed the old `_send_tx` path. The mocked `_send_tx` was never called, so the methods returned an unconfigured MagicMock instead of `{'status': 1}`.

Source logic is fine — `test_erc8183_intents.py` stayed green throughout. This is test-only alignment.

## Fix

- Stub `_execute_intent` instead of `_send_tx` in the write-op tests.
- Policy admin ops (`add_voter`/`remove_voter`/`set_quorum`) still use `_send_tx`, so that stub is kept in the policy fixture.

## Verification

```
uv run pytest -q  →  728 passed
```