### PR TITLE
chore(erc8183): sync zero-price setBudget symmetry from apex-contracts

### DIFF
--- a/abis/AgenticCommerce.json
+++ b/abis/AgenticCommerce.json
@@ -181,11 +181,6 @@
     "type": "error"
   },
   {
-    "inputs": [],
-    "name": "ZeroBudgetSellerOnly",
-    "type": "error"
-  },
-  {
     "anonymous": false,
     "inputs": [
       {

--- a/python/bnbagent/erc8183/README.md
+++ b/python/bnbagent/erc8183/README.md
@@ -170,7 +170,7 @@ High-level facade. Most useful methods:
 |--------|---------|
 | `create_job(...)` | Create a job; defaults `evaluator` and `hook` to the Router. Returns `{jobId, transactionHash, receipt}`. |
 | `register_job(job_id, policy=None)` | Bind the configured policy (or override) to a job on the Router. |
-| `set_budget(job_id, amount)` | Set the escrow amount. Client **or** provider for `amount > 0`; **provider-only for `amount == 0`** (seller-side zero price — a client-initiated zero budget reverts with `ZeroBudgetSellerOnly`). |
+| `set_budget(job_id, amount)` | Set the escrow amount. Client **or** provider, any amount — `amount == 0` is a zero-price (free) job: `fund(0)` moves no tokens and the provider verifies the funded budget against its signed quote before working. |
 | `fund(job_id, amount, *, approve_floor=None)` | Approves (if needed) and funds. See floor strategy above. `amount == 0` (a zero-price job) moves no tokens and skips the ERC-20 approve entirely. |
 | `submit(job_id, deliverable, opt_params)` | Provider submits 32-byte `deliverable` (`DeliverableManifest.manifest_hash()`, keccak256 of canonical manifest JSON); `opt_params` dict (must contain `deliverable_url`) is serialized to JSON and forwarded as `optParams`. |
 | `cancel_open(job_id, reason=...)` | Client cancels while OPEN; no escrow moved. |

--- a/python/examples/client/README.md
+++ b/python/examples/client/README.md
@@ -10,7 +10,7 @@ provider address.
 | Script | Flow | Outcome |
 |--------|------|---------|
 | `happy.py` | create → register → fund → provider submits → `settle` → **COMPLETED** | payment released, no dispute |
-| `zero_price.py` | create → register → **provider** `set_budget(0)` → `fund(0)` → provider submits → `settle` → **COMPLETED** | seller-side zero price: no escrow, nobody paid |
+| `zero_price.py` | create → register → `set_budget(0)` → `fund(0)` → provider submits → `settle` → **COMPLETED** | zero price: no escrow, nobody paid |
 | `dispute_reject.py` | submit → client `dispute` → whitelisted voters `voteReject` → `settle` → **REJECTED** | refund to client |
 | `stalemate_expire.py` | submit → client `dispute` → quorum not reached → job expires → `claimRefund` → **EXPIRED** | refund via expiry |
 | `never_submit.py` | provider never submits → job expires → `claimRefund` → **EXPIRED** | refund via expiry |
@@ -95,12 +95,12 @@ For a hermetic, no-funds-required twak tour, see `examples/twak/`.
   an out-of-band vote (see `examples/voter/`).
 - Every script is idempotent-ish: it creates a new job each run, so reruns
   don't collide.
-- `zero_price.py` demonstrates **seller-side zero price** (ERC-8183
-  `budget == 0`). Only the provider may set a zero budget — a client-initiated
-  `set_budget(0)` reverts with `ZeroBudgetSellerOnly` — so this flow
-  **requires** `PROVIDER_PRIVATE_KEY` (the provider both sets the budget and
-  submits). `fund(0)` moves no tokens and the SDK skips the ERC-20 approve
-  entirely, so the client needs no payment-token balance or allowance.
+- `zero_price.py` demonstrates **zero price** (ERC-8183 `budget == 0`).
+  `set_budget(0)` may be sent by either the client or the provider — the
+  demo drives the buyer flow (client sets the budget) and still **requires**
+  `PROVIDER_PRIVATE_KEY` for the provider-only `submit`. `fund(0)` moves no
+  tokens and the SDK skips the ERC-20 approve entirely, so the client needs
+  no payment-token balance or allowance.
 
 ## `create_and_verify.py`
 

--- a/python/examples/client/zero_price.py
+++ b/python/examples/client/zero_price.py
@@ -1,17 +1,18 @@
-"""Flow F — seller-side zero price.
+"""Flow F — zero price.
 
-A provider offers a job for free (``budget == 0``). The escrow state machine
-is unchanged (Open → Funded → Submitted → Completed), but no tokens ever
+A job agreed at price 0 (``budget == 0``). The escrow state machine is
+unchanged (Open → Funded → Submitted → Completed), but no tokens ever
 move: ``fund(0)`` deposits nothing (and the SDK skips the ERC-20 approve
 entirely), and ``settle`` pays nobody.
 
-createJob → registerJob → PROVIDER set_budget(0) → fund(0) → submit → wait
+createJob → registerJob → set_budget(0) → fund(0) → submit → wait
 past dispute window → settle → COMPLETED, with the provider's token balance
 unchanged.
 
-Zero price is **seller-side**: only the provider may set ``budget == 0`` (the
-kernel reverts a client-initiated zero budget with ``ZeroBudgetSellerOnly``).
-This demo therefore REQUIRES ``PROVIDER_PRIVATE_KEY``.
+``set_budget(0)`` may be sent by either the client or the provider — same
+rule as any other amount. This demo drives the buyer flow (the CLIENT sets
+the budget) and still REQUIRES ``PROVIDER_PRIVATE_KEY`` for the
+provider-only ``submit``.
 """
 
 from __future__ import annotations
@@ -27,8 +28,8 @@ def main() -> None:
     s = load_settings()
     if not s.provider_pk:
         raise RuntimeError(
-            "PROVIDER_PRIVATE_KEY is required for the zero-price flow: only "
-            "the provider (seller) may set budget == 0."
+            "PROVIDER_PRIVATE_KEY is required for the zero-price flow: "
+            "submit is provider-only."
         )
     client = make_primary_client(s)  # EVM or twak, per WALLET_KIND
     provider = make_client(s.provider_pk, s.network)
@@ -47,10 +48,10 @@ def main() -> None:
     client.register_job(job_id)
     print("[client] registerJob -> OptimisticPolicy")
 
-    # Seller-side: the PROVIDER sets the zero budget. A client-initiated
-    # set_budget(0) would revert with ZeroBudgetSellerOnly.
-    provider.set_budget(job_id, 0)
-    print("[provider] setBudget 0 (seller-side zero price)")
+    # The client sets the zero budget — set_budget(0) is symmetric, the
+    # provider could equally send it.
+    client.set_budget(job_id, 0)
+    print("[client] setBudget 0 (zero price)")
 
     provider_balance_before = client.token_balance(s.provider_address)
 

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -97,10 +97,9 @@ console.log(`[client] createJob jobId=${jobId}`);
 await client.registerJob(jobId!);
 
 // Escrow the budget — auto-approves the payment token if the allowance is short.
-// Seller-side zero price: for a free job the provider calls
-// `client.setBudget(jobId, 0n)` (client-initiated zero reverts with
-// `ZeroBudgetSellerOnly`), then `fund(jobId, 0n)` moves no tokens and skips the
-// ERC-20 approve entirely. See examples/client/zeroPrice.ts.
+// Zero price: for a free job either party calls `setBudget(jobId, 0n)`,
+// then `fund(jobId, 0n)` moves no tokens and skips the ERC-20 approve
+// entirely. See examples/client/zeroPrice.ts.
 await client.fund(jobId!, budget);
 console.log("[client] fund OK (Open -> Funded)");
 

--- a/typescript/examples/README.md
+++ b/typescript/examples/README.md
@@ -21,7 +21,7 @@ run e.g. `pnpm -C typescript exec tsx examples/client/happy.ts`.
 | Script | Flow |
 | --- | --- |
 | `happy.ts` | createJob → registerJob → setBudget → fund → submit → wait past dispute window → settle → `COMPLETED` |
-| `zeroPrice.ts` | createJob → registerJob → **provider** `setBudget(0)` → `fund(0)` → submit → wait past dispute window → settle → `COMPLETED` (seller-side zero price: no escrow, nobody paid) |
+| `zeroPrice.ts` | createJob → registerJob → `setBudget(0)` → `fund(0)` → submit → wait past dispute window → settle → `COMPLETED` (zero price: no escrow, nobody paid) |
 | `disputeReject.ts` | ...fund → submit → client `dispute` → whitelisted voter `voteReject` (quorum met) → settle → `REJECTED` |
 | `stalemateExpire.ts` | ...fund → submit → `dispute` with no quorum ever reached → wait past `expiredAt` → `claimRefund` → `EXPIRED` |
 | `neverSubmit.ts` | ...fund → provider stays silent → wait past `expiredAt` → `claimRefund` → `EXPIRED` |
@@ -32,10 +32,10 @@ Required env vars: `PRIVATE_KEY` (client), `PROVIDER_ADDRESS`. Optional:
 side manually if omitted), `VOTER_PRIVATE_KEY` (same, for `disputeReject.ts`),
 `NETWORK` (defaults to `bsc-testnet`).
 
-`zeroPrice.ts` demonstrates **seller-side zero price** (ERC-8183
-`budget == 0`). Only the provider may set a zero budget — a client-initiated
-`setBudget(0n)` reverts with `ZeroBudgetSellerOnly` — so this flow **requires**
-`PROVIDER_PRIVATE_KEY` (the provider both sets the budget and submits).
+`zeroPrice.ts` demonstrates **zero price** (ERC-8183 `budget == 0`).
+`setBudget(0n)` may be sent by either the client or the provider — the demo
+drives the buyer flow (client sets the budget) and still **requires**
+`PROVIDER_PRIVATE_KEY` for the provider-only `submit`.
 `fund(0n)` moves no tokens and the SDK skips the ERC-20 approve entirely, so
 the client needs no payment-token balance or allowance.
 

--- a/typescript/examples/client/zeroPrice.ts
+++ b/typescript/examples/client/zeroPrice.ts
@@ -1,19 +1,19 @@
 /**
- * Flow F — seller-side zero price.
+ * Flow F — zero price.
  *
- * A provider offers a job for free (`budget == 0`). The escrow state machine
- * is unchanged (Open -> Funded -> Submitted -> Completed), but no tokens ever
+ * A job agreed at price 0 (`budget == 0`). The escrow state machine is
+ * unchanged (Open -> Funded -> Submitted -> Completed), but no tokens ever
  * move: `fund(0)` deposits nothing (and the SDK skips the ERC-20 approve
  * entirely), and `settle` pays nobody.
  *
- * createJob -> registerJob -> PROVIDER setBudget(0) -> fund(0) -> submit ->
+ * createJob -> registerJob -> setBudget(0) -> fund(0) -> submit ->
  * wait past dispute window -> settle -> COMPLETED, with the provider's token
  * balance unchanged.
  *
- * Zero price is **seller-side**: only the provider may set `budget == 0`
- * (the kernel reverts a client-initiated zero budget with
- * `ZeroBudgetSellerOnly`). This demo therefore REQUIRES
- * `PROVIDER_PRIVATE_KEY`. Port of `python/examples/client/zero_price.py`.
+ * `setBudget(0)` may be sent by either the client or the provider — same
+ * rule as any other amount. This demo drives the buyer flow (the CLIENT
+ * sets the budget) and still REQUIRES `PROVIDER_PRIVATE_KEY` for the
+ * provider-only `submit`. Port of `python/examples/client/zero_price.py`.
  * Hits live testnet — run manually, not in CI.
  */
 
@@ -35,8 +35,8 @@ async function main(): Promise<void> {
   const s = loadSettings();
   if (!s.providerPk) {
     throw new Error(
-      "PROVIDER_PRIVATE_KEY is required for the zero-price flow: only the " +
-        "provider (seller) may set budget == 0.",
+      "PROVIDER_PRIVATE_KEY is required for the zero-price flow: `submit` " +
+        "is provider-only.",
     );
   }
   const client = await makePrimaryClient(s);
@@ -59,10 +59,10 @@ async function main(): Promise<void> {
   await client.registerJob(jobId);
   console.log("[client] registerJob -> OptimisticPolicy");
 
-  // Seller-side: the PROVIDER sets the zero budget. A client-initiated
-  // setBudget(0) would revert with ZeroBudgetSellerOnly.
-  await provider.setBudget(jobId, 0n);
-  console.log("[provider] setBudget 0 (seller-side zero price)");
+  // The client sets the zero budget — setBudget(0) is symmetric, the
+  // provider could equally send it.
+  await client.setBudget(jobId, 0n);
+  console.log("[client] setBudget 0 (zero price)");
 
   const providerBalanceBefore = await client.tokenBalance(s.providerAddress);
 

--- a/typescript/src/abis/agenticCommerce.ts
+++ b/typescript/src/abis/agenticCommerce.ts
@@ -182,11 +182,6 @@ export const agenticCommerceAbi = [
     "type": "error"
   },
   {
-    "inputs": [],
-    "name": "ZeroBudgetSellerOnly",
-    "type": "error"
-  },
-  {
     "anonymous": false,
     "inputs": [
       {


### PR DESCRIPTION
Companion to bnb-chain/apex-contracts#13 (zero-price `setBudget` opened to both parties; `ZeroBudgetSellerOnly` removed from the kernel).

## Changes

- **`abis/AgenticCommerce.json`** + generated `typescript/src/abis/agenticCommerce.ts`: remove the `ZeroBudgetSellerOnly` error entry (`pnpm codegen`). The Python SDK loads the same JSON, so one removal covers both languages.
- **`zeroPrice` examples (ts + py)**: drive the buyer flow — the CLIENT sends `setBudget(0)`; `PROVIDER_PRIVATE_KEY` is still required, but only for the provider-only `submit`.
- **READMEs**: drop the seller-side wording (`set_budget` doc row, example tables).

## No SDK logic change

`setBudget`/`fund` wrappers (viem + twak provider) are pass-through with no amount guard, the negotiation schema already specifies price as a non-negative integer string ("0" is valid), and `verifyJob`'s budget checks handle price 0 naturally (`budget < signedPrice` and the `servicePrice > 0n` gate).

## Verification

- `pnpm typecheck` / `pnpm lint` (biome) clean
- `pnpm test`: **990 passed, 1 skipped** (46 files)
- grep: zero `ZeroBudgetSellerOnly` / seller-side references left outside git history