### PR TITLE
docs: link bnbagent-studio-evals under Related

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,12 +589,7 @@ Full design rationale and threat model: see ADR #30 in the
 
 ## Related
 
-- [bnbagent-studio-evals](https://github.com/bnb-chain/bnbagent-studio-evals) —
-  security evaluation suite for BNB Agent Studio (EMNLP 2026 System Demonstrations
-  artifact). Studio-provisioned agents build their signing layer on this SDK
-  (`bnbagent.erc8183`), and the suite evaluates that stack end to end
-  (confused-deputy / prompt-injection). Originally proposed here as
-  [#48](https://github.com/bnb-chain/bnbagent-sdk/pull/48), then migrated.
+- [bnbagent-studio-evals](https://github.com/bnb-chain/bnbagent-studio-evals) — security evaluation suite for BNB Agent Studio (EMNLP 2026 System Demonstrations artifact). Studio-provisioned agents build their signing layer on this SDK (`bnbagent.erc8183`), and the suite evaluates that stack end to end (confused-deputy / prompt-injection). Originally proposed here as [#48](https://github.com/bnb-chain/bnbagent-sdk/pull/48), then migrated.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ pip install "bnbagent[ipfs]"
 - [Examples](#examples)
 - [Security](#security)
 - [Troubleshooting](#troubleshooting)
+- [Related](#related)
 - [License](#license)
 
 ---
@@ -583,6 +584,17 @@ Full design rationale and threat model: see ADR #30 in the
 | `402 Budget below service price` | `budget < ERC8183_SERVICE_PRICE` | Client must create a job with a higher budget (visible at `GET /erc8183/status`). |
 | `router.settle` reverts with `policy pending` | Dispute window hasn't elapsed and no dispute was raised | Wait until `policy.check(jobId)` returns a non-PENDING verdict, then retry. |
 | `voteReject` reverts with `not voter` / `not disputed` | Caller not whitelisted, or no dispute exists | Use [`examples/voter/vote_reject.py`](examples/voter/vote_reject.py) — it validates before sending. |
+
+---
+
+## Related
+
+- [bnbagent-studio-evals](https://github.com/bnb-chain/bnbagent-studio-evals) —
+  security evaluation suite for BNB Agent Studio (EMNLP 2026 System Demonstrations
+  artifact). Studio-provisioned agents build their signing layer on this SDK
+  (`bnbagent.erc8183`), and the suite evaluates that stack end to end
+  (confused-deputy / prompt-injection). Originally proposed here as
+  [#48](https://github.com/bnb-chain/bnbagent-sdk/pull/48), then migrated.
 
 ---
 


### PR DESCRIPTION
Adds a one-bullet **Related** section (+ TOC entry) linking to
[bnbagent-studio-evals](https://github.com/bnb-chain/bnbagent-studio-evals), so reviewers can find the evaluation suite from the SDK repo.

**Why here:** the evals repo is now public; BNB Agent Studio itself is not open-sourced yet, so this SDK is the ecosystem's public code entry point. The link is substantive, not promotional — the evaluated Studio agents build their signing layer on this SDK (`bnbagent.erc8183.NegotiationHandler`), so the suite exercises this SDK as the underlying dependency.

**Context:** the suite was originally proposed here as #48, then migrated verbatim (authorship preserved) — see the closing note on #48. This addresses the discoverability ask from the review thread.

12 insertions, README only.
