### PR TITLE
feat(ts): npm QA publishing workflow + ERC8183 env override fix

### DIFF
--- a/.github/workflows/npm-qa.yml
+++ b/.github/workflows/npm-qa.yml
@@ -1,0 +1,246 @@
+name: Publish QA (npm)
+run-name: Publish @bnbagent/sdk ${{ inputs.target_version }} QA from ${{ inputs.source_ref }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      source_ref:
+        description: "Branch or commit SHA to publish"
+        required: true
+        type: string
+      target_version:
+        description: "Intended stable version (X.Y.Z)"
+        required: true
+        default: "0.5.0"
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: npm-qa-publish
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: Verify and pack
+    runs-on: ubuntu-latest
+    outputs:
+      qa_version: ${{ steps.version.outputs.qa_version }}
+      source_sha: ${{ steps.version.outputs.source_sha }}
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: typescript/package.json
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: typescript/pnpm-lock.yaml
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Allocate the next QA version
+        id: version
+        env:
+          TARGET_VERSION: ${{ inputs.target_version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "target_version must be X.Y.Z, got: $TARGET_VERSION" >&2
+            exit 1
+          fi
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          if [[ "$PACKAGE_NAME" != "@bnbagent/sdk" ]]; then
+            echo "Refusing to publish unexpected package: $PACKAGE_NAME" >&2
+            exit 1
+          fi
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          REGISTRY_ERROR="$RUNNER_TEMP/npm-view-versions.err"
+          if ! VERSIONS_JSON="$(
+            npm view "$PACKAGE_NAME" versions --json 2>"$REGISTRY_ERROR"
+          )"; then
+            if grep -q 'E404' "$REGISTRY_ERROR"; then
+              VERSIONS_JSON='[]'
+            else
+              cat "$REGISTRY_ERROR" >&2
+              exit 1
+            fi
+          fi
+          QA_NUMBER="$(
+            TARGET_VERSION="$TARGET_VERSION" VERSIONS_JSON="$VERSIONS_JSON" node <<'NODE'
+          const parsed = JSON.parse(process.env.VERSIONS_JSON || "[]");
+          const versions = Array.isArray(parsed)
+            ? parsed
+            : typeof parsed === "string"
+              ? [parsed]
+              : [];
+          const prefix = `${process.env.TARGET_VERSION}-qa.`;
+          const numbers = versions
+            .filter((version) => version.startsWith(prefix))
+            .map((version) => version.slice(prefix.length))
+            .filter((suffix) => /^\d+$/.test(suffix))
+            .map(Number);
+          process.stdout.write(String(Math.max(0, ...numbers) + 1));
+          NODE
+          )"
+          QA_VERSION="${TARGET_VERSION}-qa.${QA_NUMBER}"
+          npm pkg set "version=$QA_VERSION"
+          echo "QA_VERSION=$QA_VERSION" >> "$GITHUB_ENV"
+          echo "qa_version=$QA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Verify ABIs are in sync
+        run: |
+          pnpm run codegen
+          git diff --exit-code src/abis
+
+      - name: Check source and build
+        run: |
+          pnpm run typecheck
+          pnpm run typecheck:examples
+          pnpm run lint
+          pnpm run test
+          pnpm run build
+
+      - name: Run offline examples
+        run: |
+          pnpm run example:x402
+          pnpm run example:security
+
+      - name: Pack and verify the installable tarball
+        id: pack
+        run: |
+          set -euo pipefail
+          PACK_DIR="$RUNNER_TEMP/npm-pack"
+          CONSUMER_DIR="$(mktemp -d)"
+          mkdir -p "$PACK_DIR"
+          npm pack --json --pack-destination "$PACK_DIR" > "$RUNNER_TEMP/npm-pack.json"
+          TARBALL_NAME="$(jq -r '.[0].filename' "$RUNNER_TEMP/npm-pack.json")"
+          TARBALL_PATH="$PACK_DIR/$TARBALL_NAME"
+          test -f "$TARBALL_PATH"
+          tar -xOf "$TARBALL_PATH" package/package.json |
+            jq -e --arg version "$QA_VERSION" \
+              '.name == "@bnbagent/sdk" and .version == $version' >/dev/null
+          cd "$CONSUMER_DIR"
+          npm init -y >/dev/null
+          npm install --ignore-scripts "$TARBALL_PATH"
+          node --input-type=module -e \
+            "await import('@bnbagent/sdk'); const { getBuiltWithValue } = await import('@bnbagent/sdk/erc8004'); const expected = 'https://github.com/bnb-chain/bnbagent-sdk#v' + process.env.QA_VERSION; if (getBuiltWithValue() !== expected) throw new Error('unexpected built_with version')"
+          node -e \
+            "require('@bnbagent/sdk'); require('@bnbagent/sdk/erc8004')"
+
+      - name: Upload verified tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: bnbagent-sdk-${{ steps.version.outputs.qa_version }}
+          path: ${{ runner.temp }}/npm-pack/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  publish:
+    name: Publish to npm
+    needs: build
+    runs-on: ubuntu-latest
+    environment: npm-qa
+    permissions:
+      contents: read
+    steps:
+      - name: Download verified tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: bnbagent-sdk-${{ needs.build.outputs.qa_version }}
+          path: package
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Verify artifact identity
+        id: artifact
+        env:
+          QA_VERSION: ${{ needs.build.outputs.qa_version }}
+        run: |
+          set -euo pipefail
+          mapfile -t TARBALLS < <(find package -maxdepth 1 -type f -name '*.tgz')
+          if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
+            echo "Expected exactly one tarball, found ${#TARBALLS[@]}" >&2
+            exit 1
+          fi
+          TARBALL="${TARBALLS[0]}"
+          tar -xOf "$TARBALL" package/package.json |
+            jq -e --arg version "$QA_VERSION" \
+              '.name == "@bnbagent/sdk" and .version == $version' >/dev/null
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
+      - name: Check whether the exact version already exists
+        id: registry
+        env:
+          QA_VERSION: ${{ needs.build.outputs.qa_version }}
+        run: |
+          if EXISTING="$(npm view "@bnbagent/sdk@$QA_VERSION" version 2>/dev/null)" &&
+            [[ "$EXISTING" == "$QA_VERSION" ]]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish under the qa dist-tag
+        if: steps.registry.outputs.exists != 'true'
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: >-
+          npm publish "${{ steps.artifact.outputs.tarball }}"
+          --access public
+          --tag qa
+          --ignore-scripts
+
+      - name: Verify registry visibility and qa dist-tag
+        env:
+          QA_VERSION: ${{ needs.build.outputs.qa_version }}
+        run: |
+          set -euo pipefail
+          for attempt in {1..12}; do
+            EXACT="$(npm view "@bnbagent/sdk@$QA_VERSION" version 2>/dev/null || true)"
+            QA_TAG="$(npm view "@bnbagent/sdk" dist-tags.qa 2>/dev/null || true)"
+            if [[ "$EXACT" == "$QA_VERSION" && "$QA_TAG" == "$QA_VERSION" ]]; then
+              exit 0
+            fi
+            if [[ "$attempt" -lt 12 ]]; then
+              echo "Waiting for npm metadata ($attempt/12)"
+              sleep 5
+            fi
+          done
+          echo "npm did not expose $QA_VERSION under the qa dist-tag" >&2
+          exit 1
+
+      - name: Write install summary
+        env:
+          QA_VERSION: ${{ needs.build.outputs.qa_version }}
+          SOURCE_SHA: ${{ needs.build.outputs.source_sha }}
+        run: |
+          {
+            echo "## @bnbagent/sdk QA package"
+            echo
+            echo "- Version: \`$QA_VERSION\`"
+            echo "- Source commit: \`$SOURCE_SHA\`"
+            echo
+            echo '```bash'
+            echo "pnpm add -E @bnbagent/sdk@$QA_VERSION"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bnbagent/sdk",
-  "version": "0.1.0",
+  "version": "0.5.0",
   "description": "TypeScript SDK for building on-chain AI agents on BNB Chain (ERC-8004 identity, ERC-8183 agentic commerce, x402 payments).",
   "license": "MIT",
   "repository": {

--- a/typescript/src/erc8183/client.ts
+++ b/typescript/src/erc8183/client.ts
@@ -34,7 +34,7 @@
 
 import type { PublicClient } from "viem";
 import { stringToHex } from "viem";
-import { type NetworkConfig, resolveNetwork } from "../config.js";
+import type { NetworkConfig } from "../config.js";
 import { canonicalJson } from "../core/canonicalJson.js";
 import { createPublicClientFor } from "../core/clients.js";
 import { READ_ONLY_MESSAGE } from "../core/contractBase.js";
@@ -44,6 +44,7 @@ import { MinimalERC20Client } from "../erc20/client.js";
 import type { TxResult } from "../wallets/intents.js";
 import type { WalletProvider } from "../wallets/walletProvider.js";
 import { CommerceClient, type CreateJobResult } from "./commerce.js";
+import { resolveErc8183Network } from "./constants.js";
 import { PolicyClient } from "./policy.js";
 import { RouterClient } from "./router.js";
 import {
@@ -172,6 +173,10 @@ export class ERC8183Client {
   /**
    * Create an `ERC8183Client`.
    *
+   * A string `network` resolves through the ERC-8183 env overlay
+   * (`ERC8183_*_ADDRESS` overrides apply — how a QA/staging stack is
+   * targeted); a concrete `NetworkConfig` is used as-is.
+   *
    * Connects to the network's RPC and asserts its `chain_id` matches the
    * resolved network config (defense-in-depth against a misconfigured or
    * maliciously redirected RPC URL) before returning.
@@ -187,7 +192,7 @@ export class ERC8183Client {
     const network = opts.network ?? "bsc-testnet";
     const debug = opts.debug ?? false;
 
-    const nc = resolveNetwork(network);
+    const nc = resolveErc8183Network(network);
     for (const [fieldName, key] of REQUIRED_NETWORK_FIELDS) {
       if (!nc[key]) {
         throw new Error(

--- a/typescript/src/erc8183/config.ts
+++ b/typescript/src/erc8183/config.ts
@@ -44,7 +44,7 @@
  * TypeScript port yet).
  */
 
-import { type NetworkConfig, resolveNetwork } from "../config.js";
+import type { NetworkConfig } from "../config.js";
 import { getEnv } from "../core/envUtil.js";
 import { LocalStorageProvider } from "../storage/localStorageProvider.js";
 import type { StorageProvider } from "../storage/storageProvider.js";
@@ -54,7 +54,7 @@ import {
   TWAK_CHAIN_FOR_NETWORK,
 } from "../wallets/twak/provider.js";
 import type { WalletProvider } from "../wallets/walletProvider.js";
-import { ERC8183_ENV_PREFIX } from "./constants.js";
+import { ERC8183_ENV_PREFIX, resolveErc8183Network } from "./constants.js";
 
 /** Constructor options for {@link ERC8183Config}. */
 export interface ERC8183ConfigOpts {
@@ -213,31 +213,7 @@ export class ERC8183Config {
    * full control — env overrides are not applied.
    */
   get effectiveNetwork(): NetworkConfig {
-    const base = resolveNetwork(this.network);
-    if (typeof this.network !== "string") {
-      return base;
-    }
-    const commerceOverride = getEnv(
-      "COMMERCE_ADDRESS",
-      undefined,
-      ERC8183_ENV_PREFIX,
-    );
-    const routerOverride = getEnv(
-      "ROUTER_ADDRESS",
-      undefined,
-      ERC8183_ENV_PREFIX,
-    );
-    const policyOverride = getEnv(
-      "POLICY_ADDRESS",
-      undefined,
-      ERC8183_ENV_PREFIX,
-    );
-    return {
-      ...base,
-      commerceContract: commerceOverride ?? base.commerceContract,
-      routerContract: routerOverride ?? base.routerContract,
-      policyContract: policyOverride ?? base.policyContract,
-    };
+    return resolveErc8183Network(this.network);
   }
 
   get effectiveRpcUrl(): string {

--- a/typescript/src/erc8183/constants.ts
+++ b/typescript/src/erc8183/constants.ts
@@ -44,3 +44,32 @@ export function getErc8183Config(
       nc.policyContract,
   };
 }
+
+/**
+ * Resolve `network` to a `NetworkConfig` with the ERC-8183 env overlay.
+ *
+ * String preset → the `ERC8183_*_ADDRESS` env overrides are applied on top
+ * of the resolved preset (how a QA/staging contract stack is targeted
+ * without code changes). Concrete `NetworkConfig` object → returned as
+ * resolved; the caller takes full control and env overrides are ignored.
+ */
+export function resolveErc8183Network(
+  network: string | NetworkConfig = "bsc-testnet",
+): NetworkConfig {
+  const nc = resolveNetwork(network);
+  if (typeof network !== "string") {
+    return nc;
+  }
+  return {
+    ...nc,
+    commerceContract:
+      getEnv("COMMERCE_ADDRESS", undefined, ERC8183_ENV_PREFIX) ??
+      nc.commerceContract,
+    routerContract:
+      getEnv("ROUTER_ADDRESS", undefined, ERC8183_ENV_PREFIX) ??
+      nc.routerContract,
+    policyContract:
+      getEnv("POLICY_ADDRESS", undefined, ERC8183_ENV_PREFIX) ??
+      nc.policyContract,
+  };
+}

--- a/typescript/src/erc8183/index.ts
+++ b/typescript/src/erc8183/index.ts
@@ -50,7 +50,11 @@ export {
   type SubmitOptParams,
 } from "./client.js";
 export { ERC8183Config, type ERC8183ConfigOpts } from "./config.js";
-export { ERC8183_ENV_PREFIX, getErc8183Config } from "./constants.js";
+export {
+  ERC8183_ENV_PREFIX,
+  getErc8183Config,
+  resolveErc8183Network,
+} from "./constants.js";
 export {
   ERC8183JobOps,
   type ERC8183JobOpsCreateOpts,

--- a/typescript/src/version.ts
+++ b/typescript/src/version.ts
@@ -1,10 +1,10 @@
+import packageJson from "../package.json" with { type: "json" };
+
 /**
  * SDK version, used to build the `built_with` ERC-8004 metadata tag
  * (`https://github.com/bnb-chain/bnbagent-sdk#v<version>`).
  *
- * Hardcoded rather than read from `package.json` at runtime — this file is
- * bundled by `tsup` into both ESM and CJS outputs, and importing JSON keeps
- * the value in lockstep with `package.json` without adding a build step.
- * Keep this in sync with `package.json`'s `version` field.
+ * `tsup` inlines this value into the ESM and CJS bundles, so installed
+ * packages do not read package.json at runtime.
  */
-export const SDK_VERSION = "0.1.0";
+export const SDK_VERSION = packageJson.version;

--- a/typescript/tests/erc8183Client.test.ts
+++ b/typescript/tests/erc8183Client.test.ts
@@ -277,6 +277,49 @@ describe("ERC8183Client.create", () => {
     expect(client.address).toBe(WALLET_ADDRESS);
     expect(client.network.name).toBe("test-net");
   });
+
+  it("applies ERC8183_*_ADDRESS env overrides to a string preset (QA stack)", async () => {
+    // Digit-only addresses are checksum-invariant, so they compare verbatim.
+    const overrides = {
+      ERC8183_COMMERCE_ADDRESS: `0x${"44".repeat(20)}`,
+      ERC8183_ROUTER_ADDRESS: `0x${"55".repeat(20)}`,
+      ERC8183_POLICY_ADDRESS: `0x${"66".repeat(20)}`,
+    };
+    Object.assign(process.env, overrides);
+    try {
+      const mock = mockPublicClient({
+        eth_chainId: () => toChainIdHex(97),
+        eth_call: combinedReadHandler(defaultResults()),
+      });
+      createPublicClientForMock.mockReset().mockReturnValue(mock.client);
+      const client = await ERC8183Client.create({ network: "bsc-testnet" });
+      expect(client.network.commerceContract).toBe(
+        overrides.ERC8183_COMMERCE_ADDRESS,
+      );
+      expect(client.network.routerContract).toBe(
+        overrides.ERC8183_ROUTER_ADDRESS,
+      );
+      expect(client.network.policyContract).toBe(
+        overrides.ERC8183_POLICY_ADDRESS,
+      );
+      expect(client.commerce.address).toBe(overrides.ERC8183_COMMERCE_ADDRESS);
+      expect(client.router.address).toBe(overrides.ERC8183_ROUTER_ADDRESS);
+      expect(client.policy.address).toBe(overrides.ERC8183_POLICY_ADDRESS);
+    } finally {
+      for (const key of Object.keys(overrides)) delete process.env[key];
+    }
+  });
+
+  it("ignores ERC8183_* env when network is a concrete NetworkConfig (caller takes full control)", async () => {
+    const overrides = { ERC8183_COMMERCE_ADDRESS: `0x${"44".repeat(20)}` };
+    Object.assign(process.env, overrides);
+    try {
+      const { client } = await buildClient({});
+      expect(client.network.commerceContract).toBe(FAKE_COMMERCE);
+    } finally {
+      for (const key of Object.keys(overrides)) delete process.env[key];
+    }
+  });
 });
 
 describe("ERC8183Client: paymaster wiring", () => {

--- a/typescript/tests/version.test.ts
+++ b/typescript/tests/version.test.ts
@@ -1,0 +1,11 @@
+import { expect, test } from "vitest";
+import packageJson from "../package.json" with { type: "json" };
+import { getBuiltWithValue } from "../src/erc8004/constants.js";
+import { SDK_VERSION } from "../src/version.js";
+
+test("SDK metadata uses the package version", () => {
+  expect(SDK_VERSION).toBe(packageJson.version);
+  expect(getBuiltWithValue()).toBe(
+    `https://github.com/bnb-chain/bnbagent-sdk#v${packageJson.version}`,
+  );
+});


### PR DESCRIPTION
Replaces #57 — identical content, tip commit re-signed (the repo ruleset blocks force-push, so the original branch could not be rewritten in place). Both commits are GPG-signed.

## What

Two commits toward the first QA package of `@bnbagent/sdk`:

1. **`npm-qa.yml` publish workflow** (`workflow_dispatch`): allocates the next `<target>-qa.N` by querying the registry (E404-safe for the first-ever publish), verifies ABIs/typecheck/lint/tests/build/offline examples, packs and install-smokes the tarball in a clean consumer (ESM + CJS + `built_with` version stamp), then publishes the **verified artifact** under the `qa` dist-tag (`--access public --ignore-scripts`), idempotent if the version already exists, and polls until the registry exposes the version + tag.
2. **fix: `ERC8183Client.create` honors `ERC8183_*_ADDRESS` env overrides.** `create()` resolved presets via bare `resolveNetwork()`, so the documented QA env injection never reached the main client entry point (only `ERC8183Config.effectiveNetwork` applied it). Extracted `resolveErc8183Network()` — string preset gets the env overlay, explicit `NetworkConfig` stays caller-controlled — used by both paths. Without this, the QA package could not target the `bscTestnetQa` stack.

## Verification

- Full check green: typecheck, lint, 1022 tests (+2 new for the env overlay), build.
- On-chain smoke against the deployed `bscTestnetQa` stack (env-injected commerce/router/policy): chain-id guard passes, `paymentToken()` returns the canonical U token (`0xc70B…5565`, 18 decimals), `disputeWindow` reads 259200s.

## Before the first dispatch

- Create the `npm-qa` environment (Settings → Environments) and set `NPM_TOKEN` (automation token with publish rights on the `@bnbagent` org).
- `@bnbagent/sdk` does not exist on npm yet (404) — this run is the first-ever publish; expected version `0.5.0-qa.1`.
- Known/intended npm behavior: first publish with `--tag qa` sets **only** the `qa` dist-tag; `latest` stays absent until the first stable release, so bare `npm install @bnbagent/sdk` fails while QA-only — install with `@qa` or the exact version.
- Dispatch the workflow from a ref that contains `npm-qa.yml` (this branch, or `feat-tssdk` after merge).