### PR TITLE
fix(ci): pass npm publish an absolute tarball path

### DIFF
--- a/.github/workflows/npm-qa.yml
+++ b/.github/workflows/npm-qa.yml
@@ -177,7 +177,9 @@ jobs:
           QA_VERSION: ${{ needs.build.outputs.qa_version }}
         run: |
           set -euo pipefail
-          mapfile -t TARBALLS < <(find package -maxdepth 1 -type f -name '*.tgz')
+          # Absolute path: npm parses a bare "package/x.tgz" argument as a
+          # GitHub owner/repo shorthand, not a file.
+          mapfile -t TARBALLS < <(find "$PWD/package" -maxdepth 1 -type f -name '*.tgz')
           if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
             echo "Expected exactly one tarball, found ${#TARBALLS[@]}" >&2
             exit 1


### PR DESCRIPTION
First QA publish attempt ([run 30442357224](https://github.com/bnb-chain/bnbagent-sdk/actions/runs/30442357224)) failed at the publish step: npm parsed the bare relative argument `package/bnbagent-sdk-0.5.0-qa.1.tgz` as a **GitHub `owner/repo` shorthand** (tried `git ls-remote ssh://git@github.com/package/bnbagent-sdk-0.5.0-qa.1.tgz.git`, exit 128) instead of a local file — npm only treats specs starting with `./`, `/`, `~`, or `file:` as paths.

**Nothing was published** — the failure happened before any upload; the registry is still empty, so the next run allocates `0.5.0-qa.1` again.

Fix: resolve the tarball via `find "$PWD/package"` so the publish step gets an absolute path. Build-job steps were unaffected (they already used absolute `$RUNNER_TEMP` paths).

After merge: re-dispatch "Publish QA (npm)" with `source_ref=feat-tssdk`, `target_version=0.5.0`.