### PR TITLE
fix(ci): survive npm CDN lag when verifying a QA publish

### DIFF
--- a/.github/workflows/npm-qa.yml
+++ b/.github/workflows/npm-qa.yml
@@ -217,19 +217,31 @@ jobs:
           QA_VERSION: ${{ needs.build.outputs.qa_version }}
         run: |
           set -euo pipefail
-          for attempt in {1..12}; do
-            EXACT="$(npm view "@bnbagent/sdk@$QA_VERSION" version 2>/dev/null || true)"
-            QA_TAG="$(npm view "@bnbagent/sdk" dist-tags.qa 2>/dev/null || true)"
-            if [[ "$EXACT" == "$QA_VERSION" && "$QA_TAG" == "$QA_VERSION" ]]; then
-              exit 0
+          # Poll the version document, not the packument: every `npm view` of a
+          # not-yet-published package leaves a 404 in the registry CDN, and
+          # that negative entry outlived a 60s window on the first publish
+          # (run 30444482337 went red minutes after a successful upload).
+          # The per-version document has no such history and goes live at once.
+          for attempt in {1..20}; do
+            if curl -fsS -o /dev/null \
+              "https://registry.npmjs.org/@bnbagent%2Fsdk/$QA_VERSION?cb=$attempt"
+            then
+              echo "$QA_VERSION is live on the registry"
+              break
             fi
-            if [[ "$attempt" -lt 12 ]]; then
-              echo "Waiting for npm metadata ($attempt/12)"
-              sleep 5
+            if [[ "$attempt" -eq 20 ]]; then
+              echo "::error::$QA_VERSION is still absent 5 minutes after publish" >&2
+              exit 1
             fi
+            echo "Waiting for $QA_VERSION ($attempt/20)"
+            sleep 15
           done
-          echo "npm did not expose $QA_VERSION under the qa dist-tag" >&2
-          exit 1
+          # Advisory only — the upload is done and irreversible, so packument
+          # lag must not turn a completed publish into a red run.
+          QA_TAG="$(npm view "@bnbagent/sdk" dist-tags.qa 2>/dev/null || true)"
+          if [[ "$QA_TAG" != "$QA_VERSION" ]]; then
+            echo "::warning::qa dist-tag reads '${QA_TAG:-<unset>}', expected $QA_VERSION (packument CDN lag) — recheck with 'npm view @bnbagent/sdk dist-tags'"
+          fi
 
       - name: Write install summary
         env:


### PR DESCRIPTION
`@bnbagent/sdk@0.5.0-qa.1` **published successfully** — it is live and public on npm. But [run 30444482337](https://github.com/bnb-chain/bnbagent-sdk/actions/runs/30444482337) still went red: the post-publish verification step polled the **packument** (`/@bnbagent%2Fsdk`) for 60s and hard-failed.

**Root cause:** every `npm view` of a not-yet-published package leaves a 404 in the registry CDN. Between the version-allocation step, local checks, and two earlier failed runs, that negative entry was well established, and it outlived the 60s window. Measured right after the run: the per-version document `/@bnbagent%2Fsdk/0.5.0-qa.1` and the tarball were **200 immediately**, while the packument kept serving the cached 404 and only flipped to 200 a few minutes later (`cf-cache-status: HIT, age: 38`).

**Fix:**
- Poll the **per-version document** (no 404 history, live at once) with a per-attempt cache-buster, over 5 minutes instead of 1.
- Demote the dist-tag comparison to a `::warning`. The upload is irreversible — once publish returns, packument lag must not turn a completed publish into a failed run that invites a confusing re-run.

No re-publish is needed; this only affects future QA versions (`qa.2`+).

**Side note for the record:** npm set **both** `qa` and `latest` to `0.5.0-qa.1` — a package's first-ever publish always gets `latest` regardless of `--tag`. So bare `npm install @bnbagent/sdk` currently resolves to the QA prerelease; it self-corrects when `0.5.0` stable is published without `--tag`.