### PR TITLE
fix: neutralised x402 session budget via signed-integer type coercion (SRC-1314, Python)

### DIFF
--- a/bnbagent/signing/checks.py
+++ b/bnbagent/signing/checks.py
@@ -166,9 +166,23 @@ def _check_field_shape(
     swapping in ``int256`` removes a value-domain guard the downstream layers
     were relying on. Field order and count matter too — both feed the typeHash.
 
-    Only structs in :data:`EIP3009_CANONICAL_FIELDS`'s scope are pinned;
-    unknown types are left to the allowlist so ``permissive()`` and custom
-    ``extend()`` callers keep working.
+    Scope is keyed on the struct **name**, not on the policy: anything calling
+    itself ``TransferWithAuthorization`` is held to the EIP-3009 shape even
+    under ``permissive()``, because the canonical shape is a property of the
+    name rather than of the ruleset. Types with any other name are untouched,
+    so custom ``extend()`` primary types keep working.
+
+    Two neighbouring surfaces are deliberately left unpinned:
+
+    * ``EIP712Domain`` — EIP-712 makes every domain field optional, so there is
+      no single canonical shape to pin against (``salt`` is legitimate, so is
+      omitting ``version``). Checked for exploitability: altering the domain
+      shape changes the domainSeparator, which makes the resulting signature
+      useless against the real token, and an out-of-range ``chainId`` cannot
+      pass the domain allowlist either.
+    * The Permit2 family (:data:`PERMIT2_SIGNATURE_TRANSFER_TYPES`) — opt-in
+      via ``extend()`` only, and the SDK carries no canonical field table for
+      them. Pin them here if they ever enter a default policy.
     """
     if primary_type not in EIP3009_TYPES:
         return

--- a/bnbagent/signing/checks.py
+++ b/bnbagent/signing/checks.py
@@ -13,7 +13,7 @@ from typing import Any
 from web3 import Web3
 
 from .errors import PolicyViolation
-from .policy import SigningPolicy
+from .policy import EIP3009_CANONICAL_FIELDS, EIP3009_TYPES, SigningPolicy
 
 EIP712_DOMAIN_TYPE_NAME = "EIP712Domain"
 
@@ -140,11 +140,63 @@ def check(
                 verifying_contract=verifying,
             )
 
+    # ── Field-shape pinning for known structs ────────────────────────
+    _check_field_shape(types, primary_type, chain_id, verifying)
+
     # ── Validity window (only if primary type requires it) ───────────
     if primary_type in policy.validity_required_primary_types:
         _check_validity(policy, primary_type, message, chain_id, verifying, now)
 
     return primary_type
+
+
+def _check_field_shape(
+    types: dict[str, Any],
+    primary_type: str,
+    chain_id: int,
+    verifying: str,
+) -> None:
+    """Pin the field-shape of structs whose shape we know canonically.
+
+    The allowlist above is name-scoped, and ``types`` is caller-supplied — for
+    x402 it arrives verbatim in an untrusted 402 response body. Without this
+    check an attacker keeps the allowlisted name and rewrites the field's
+    Solidity type, which silently changes what the encoder will accept: the
+    canonical ``uint256`` is what makes a negative ``value`` unencodable, so
+    swapping in ``int256`` removes a value-domain guard the downstream layers
+    were relying on. Field order and count matter too — both feed the typeHash.
+
+    Only structs in :data:`EIP3009_CANONICAL_FIELDS`'s scope are pinned;
+    unknown types are left to the allowlist so ``permissive()`` and custom
+    ``extend()`` callers keep working.
+    """
+    if primary_type not in EIP3009_TYPES:
+        return
+    fields = types.get(primary_type)
+    if not isinstance(fields, list):
+        raise PolicyViolation(
+            f"types[{primary_type!r}] must be a list of field descriptors, "
+            f"got {type(fields).__name__}",
+            primary_type=primary_type,
+            chain_id=chain_id,
+            verifying_contract=verifying,
+        )
+    actual = tuple(
+        (f.get("name"), f.get("type")) if isinstance(f, dict) else (None, None)
+        for f in fields
+    )
+    if actual != EIP3009_CANONICAL_FIELDS:
+        expected_repr = ", ".join(f"{n} {t}" for n, t in EIP3009_CANONICAL_FIELDS)
+        actual_repr = ", ".join(f"{n} {t}" for n, t in actual)
+        raise PolicyViolation(
+            f"types[{primary_type!r}] does not match the canonical EIP-3009 "
+            f"field shape — refusing to sign a struct whose encoding differs "
+            f"from the on-chain type. expected ({expected_repr}), "
+            f"got ({actual_repr})",
+            primary_type=primary_type,
+            chain_id=chain_id,
+            verifying_contract=verifying,
+        )
 
 
 def _check_validity(

--- a/bnbagent/signing/policy.py
+++ b/bnbagent/signing/policy.py
@@ -40,6 +40,20 @@ EIP3009_TYPES: frozenset[str] = frozenset({
     "ReceiveWithAuthorization",
 })
 
+# Field-shape of both EIP-3009 authorization structs (name, solidity type),
+# in declaration order. EIP-712 hashes the field names, types *and* order into
+# the typeHash, so this tuple is the struct's on-chain identity — pinning it
+# is what makes the allowlist above mean "this exact struct" rather than just
+# "a struct that happens to carry this name".
+EIP3009_CANONICAL_FIELDS: tuple[tuple[str, str], ...] = (
+    ("from", "address"),
+    ("to", "address"),
+    ("value", "uint256"),
+    ("validAfter", "uint256"),
+    ("validBefore", "uint256"),
+    ("nonce", "bytes32"),
+)
+
 PERMIT_UNBOUNDED_TYPES: frozenset[str] = frozenset({
     "Permit",          # EIP-2612 — long-lived allowance to a spender
     "PermitSingle",    # Permit2 AllowanceTransfer — long-lived allowance

--- a/bnbagent/x402/budget.py
+++ b/bnbagent/x402/budget.py
@@ -83,7 +83,11 @@ class SessionBudgetTracker:
         return self._spent.get(cs, 0) + int(amount) > cap
 
     def commit(self, token: str, amount: int) -> None:
-        """Record a successful spend (unconditional increment under lock).
+        """Record a successful spend (increment under lock, no cap check).
+
+        Does not test the cap — that is the caller's job via
+        :meth:`would_exceed`. It does still reject a negative ``amount``,
+        so "unconditional" applies to the cap only (SRC-1314).
 
         ⚠️ Race-unsafe when paired with a separate :meth:`would_exceed`
         check — the gap between check and commit is exactly the TOCTOU

--- a/bnbagent/x402/budget.py
+++ b/bnbagent/x402/budget.py
@@ -26,6 +26,24 @@ from web3 import Web3
 from .errors import X402BudgetExhaustedError
 
 
+def _non_negative(amount: int) -> int:
+    """Coerce to int and refuse negatives — the counter's load-bearing invariant.
+
+    The cap test is a one-sided ``cur + amt > cap``, so a negative ``amt``
+    shrinks the sum and passes trivially while driving the counter negative;
+    every later spend then measures against a huge negative baseline and the
+    session cap stops binding. :meth:`SessionBudgetTracker.rollback` already
+    floors at zero, but that is the decrement side, where the invariant is
+    only defensive — it has to hold on the increment side to mean anything.
+    """
+    amt = int(amount)
+    if amt < 0:
+        raise X402BudgetExhaustedError(
+            f"budget amount must be non-negative, got {amt}"
+        )
+    return amt
+
+
 class SessionBudgetTracker:
     """Per-token cumulative spend tracker with caps."""
 
@@ -71,10 +89,15 @@ class SessionBudgetTracker:
         check — the gap between check and commit is exactly the TOCTOU
         window. Use :meth:`reserve` for new code; ``commit`` is retained
         for backwards compatibility.
+
+        Raises:
+            X402BudgetExhaustedError: If ``amount`` is negative (see
+                :meth:`reserve` for why).
         """
         cs = Web3.to_checksum_address(token)
+        amt = _non_negative(amount)
         with self._lock:
-            self._spent[cs] = self._spent.get(cs, 0) + int(amount)
+            self._spent[cs] = self._spent.get(cs, 0) + amt
 
     def reserve(self, token: str, amount: int) -> None:
         """Atomic check-and-increment for the session budget.
@@ -87,10 +110,11 @@ class SessionBudgetTracker:
         concurrency.
 
         Raises:
-            X402BudgetExhaustedError: If reservation would exceed the cap.
+            X402BudgetExhaustedError: If reservation would exceed the cap, or
+                if ``amount`` is negative.
         """
         cs = Web3.to_checksum_address(token)
-        amt = int(amount)
+        amt = _non_negative(amount)
         with self._lock:
             cap = self._caps.get(cs)
             cur = self._spent.get(cs, 0)

--- a/bnbagent/x402/signer.py
+++ b/bnbagent/x402/signer.py
@@ -137,8 +137,8 @@ class X402Signer:
         Raises:
             X402RecipientMismatchError: ``message['to']`` differs from
                 ``expected_to``.
-            X402AmountExceededError: ``message['value']`` exceeds per-call
-                ``max_value_per_call`` for this token.
+            X402AmountExceededError: ``message['value']`` is negative, or
+                exceeds per-call ``max_value_per_call`` for this token.
             X402BudgetExhaustedError: session budget would be exceeded.
             X402PolicyError: wraps an underlying
                 :class:`bnbagent.signing.PolicyViolation`.
@@ -159,6 +159,14 @@ class X402Signer:
 
         # ── L1 per-call value cap ─────────────────────────────────
         value = int(message.get("value", 0))
+        # int() widens rather than validates: the declared uint256 field-shape
+        # is not enforced here, so a negative slips through the one-sided cap
+        # test below and neutralises the session budget. Refuse before
+        # reserve() so a rejected call still costs no budget.
+        if value < 0:
+            raise X402AmountExceededError(
+                f"message['value'] must be non-negative, got {value}"
+            )
         cap = self._max_value.get(verifying)
         if cap is not None and value > cap:
             raise X402AmountExceededError(

--- a/tests/test_signing_policy.py
+++ b/tests/test_signing_policy.py
@@ -59,7 +59,14 @@ def _twa_msg(*, valid_after=None, valid_before=None):
     }
 
 
-def _twa_call(policy, *, domain_overrides=None, message_overrides=None, now=NOW):
+def _twa_call(
+    policy,
+    *,
+    domain_overrides=None,
+    message_overrides=None,
+    twa_fields=None,
+    now=NOW,
+):
     domain = {
         "name": "United Stables",
         "version": "1",
@@ -68,7 +75,10 @@ def _twa_call(policy, *, domain_overrides=None, message_overrides=None, now=NOW)
     }
     if domain_overrides:
         domain.update(domain_overrides)
-    types = {"EIP712Domain": EIP712DOMAIN_FIELDS, "TransferWithAuthorization": TWA_FIELDS}
+    types = {
+        "EIP712Domain": EIP712DOMAIN_FIELDS,
+        "TransferWithAuthorization": TWA_FIELDS if twa_fields is None else twa_fields,
+    }
     msg = _twa_msg()
     if message_overrides:
         msg.update(message_overrides)
@@ -203,6 +213,113 @@ def test_rejects_missing_validity_fields_when_required():
     msg = {"from": "0x" + "a" * 40, "to": "0x" + "b" * 40, "value": 1}
     with pytest.raises(PolicyViolation, match="requires validBefore"):
         check(p, domain, types, msg, now=NOW)
+
+
+# ── EIP-3009 field-shape pinning (SRC-1314) ──────────────────────────────
+# The allowlist is name-scoped and `types` is caller-supplied (for x402 it
+# comes straight out of an untrusted 402 response body). Keeping the
+# allowlisted name while rewriting the field shape changes what the encoder
+# accepts, which is how a value-domain guard got silently removed.
+
+
+def _twa_fields_with(name, key, new_value):
+    return [
+        {**f, key: new_value} if f["name"] == name else f for f in TWA_FIELDS
+    ]
+
+
+def test_rejects_value_declared_as_int256():
+    """The exploit primitive: int256 makes a negative `value` encodable.
+
+    Note the message here carries a perfectly ordinary positive value — this
+    is rejected on field shape alone, so the guard stands on its own rather
+    than depending on the amount checks downstream.
+    """
+    p = SigningPolicy.strict_default()
+    with pytest.raises(PolicyViolation, match="canonical EIP-3009 field shape"):
+        _twa_call(p, twa_fields=_twa_fields_with("value", "type", "int256"))
+
+
+def test_rejects_narrowed_value_type():
+    p = SigningPolicy.strict_default()
+    with pytest.raises(PolicyViolation, match="canonical EIP-3009 field shape"):
+        _twa_call(p, twa_fields=_twa_fields_with("value", "type", "uint128"))
+
+
+def test_rejects_reordered_fields():
+    """Order feeds the typeHash, so a reorder is a different struct."""
+    p = SigningPolicy.strict_default()
+    swapped = [TWA_FIELDS[1], TWA_FIELDS[0], *TWA_FIELDS[2:]]
+    with pytest.raises(PolicyViolation, match="canonical EIP-3009 field shape"):
+        _twa_call(p, twa_fields=swapped)
+
+
+def test_rejects_extra_field():
+    p = SigningPolicy.strict_default()
+    with pytest.raises(PolicyViolation, match="canonical EIP-3009 field shape"):
+        _twa_call(p, twa_fields=[*TWA_FIELDS, {"name": "memo", "type": "bytes32"}])
+
+
+def test_rejects_missing_field():
+    p = SigningPolicy.strict_default()
+    with pytest.raises(PolicyViolation, match="canonical EIP-3009 field shape"):
+        _twa_call(p, twa_fields=TWA_FIELDS[:-1])
+
+
+def test_rejects_renamed_field():
+    p = SigningPolicy.strict_default()
+    with pytest.raises(PolicyViolation, match="canonical EIP-3009 field shape"):
+        _twa_call(p, twa_fields=_twa_fields_with("value", "name", "amount"))
+
+
+def test_rejects_non_list_field_descriptor():
+    p = SigningPolicy.strict_default()
+    with pytest.raises(PolicyViolation, match="must be a list of field descriptors"):
+        _twa_call(p, twa_fields={"from": "address"})
+
+
+def test_field_shape_violation_carries_diagnostics():
+    p = SigningPolicy.strict_default()
+    with pytest.raises(PolicyViolation) as exc:
+        _twa_call(p, twa_fields=_twa_fields_with("value", "type", "int256"))
+    assert exc.value.primary_type == "TransferWithAuthorization"
+    assert exc.value.chain_id == BSC_MAINNET_CHAIN_ID
+    assert exc.value.verifying_contract == U_MAINNET
+
+
+def test_canonical_shape_still_accepted():
+    """Guard against the pin being too tight to sign the real thing."""
+    p = SigningPolicy.strict_default()
+    assert _twa_call(p) == "TransferWithAuthorization"
+
+
+def test_receive_with_authorization_shares_the_canonical_shape():
+    p = SigningPolicy.strict_default()
+    domain = {
+        "name": "United Stables", "version": "1",
+        "chainId": BSC_MAINNET_CHAIN_ID, "verifyingContract": U_MAINNET,
+    }
+    types = {
+        "EIP712Domain": EIP712DOMAIN_FIELDS,
+        "ReceiveWithAuthorization": TWA_FIELDS,
+    }
+    assert check(p, domain, types, _twa_msg(), now=NOW) == "ReceiveWithAuthorization"
+
+
+def test_unknown_primary_type_is_not_shape_pinned():
+    """Shape pinning applies only to the structs we know canonically —
+    permissive()/extend() callers signing custom types keep working.
+    """
+    p = SigningPolicy.permissive(allow_in_production=True)
+    domain = {
+        "name": "Custom", "version": "1",
+        "chainId": BSC_MAINNET_CHAIN_ID, "verifyingContract": U_MAINNET,
+    }
+    types = {
+        "EIP712Domain": EIP712DOMAIN_FIELDS,
+        "MyCustomStruct": [{"name": "whatever", "type": "int256"}],
+    }
+    assert check(p, domain, types, {"whatever": -5}, now=NOW) == "MyCustomStruct"
 
 
 # ── Structure / domain shape ─────────────────────────────────────────────

--- a/tests/test_signing_policy.py
+++ b/tests/test_signing_policy.py
@@ -307,8 +307,8 @@ def test_receive_with_authorization_shares_the_canonical_shape():
 
 
 def test_unknown_primary_type_is_not_shape_pinned():
-    """Shape pinning applies only to the structs we know canonically —
-    permissive()/extend() callers signing custom types keep working.
+    """Shape pinning is keyed on the struct name, so a differently-named custom
+    type is untouched — permissive()/extend() callers keep working.
     """
     p = SigningPolicy.permissive(allow_in_production=True)
     domain = {
@@ -320,6 +320,44 @@ def test_unknown_primary_type_is_not_shape_pinned():
         "MyCustomStruct": [{"name": "whatever", "type": "int256"}],
     }
     assert check(p, domain, types, {"whatever": -5}, now=NOW) == "MyCustomStruct"
+
+
+def test_shape_pin_applies_even_under_permissive():
+    """The pin is keyed on the struct NAME, not on the policy.
+
+    permissive() opts out of the allowlist, not out of the canonical shape: a
+    struct calling itself TransferWithAuthorization is held to the EIP-3009
+    shape regardless of ruleset, because the shape belongs to the name. This
+    test exists to pin that decision down — it is the one behavioural
+    consequence of the SRC-1314 fix that is not obvious from the allowlist.
+    """
+    p = SigningPolicy.permissive(allow_in_production=True)
+    with pytest.raises(PolicyViolation, match="canonical EIP-3009 field shape"):
+        _twa_call(p, twa_fields=_twa_fields_with("value", "type", "int256"))
+
+
+def test_eip712domain_shape_is_not_pinned():
+    """EIP712Domain is deliberately left unpinned — EIP-712 makes every domain
+    field optional, so there is no single canonical shape to pin against.
+
+    Documented as checked-and-cleared rather than overlooked: altering the
+    domain shape changes the domainSeparator, so the signature is useless
+    against the real token.
+    """
+    p = SigningPolicy.strict_default()
+    odd_domain_fields = [
+        *EIP712DOMAIN_FIELDS,
+        {"name": "salt", "type": "bytes32"},
+    ]
+    domain = {
+        "name": "United Stables", "version": "1",
+        "chainId": BSC_MAINNET_CHAIN_ID, "verifyingContract": U_MAINNET,
+    }
+    types = {
+        "EIP712Domain": odd_domain_fields,
+        "TransferWithAuthorization": TWA_FIELDS,
+    }
+    assert check(p, domain, types, _twa_msg(), now=NOW) == "TransferWithAuthorization"
 
 
 # ── Structure / domain shape ─────────────────────────────────────────────

--- a/tests/test_x402_signer.py
+++ b/tests/test_x402_signer.py
@@ -9,6 +9,7 @@ import pytest
 from bnbagent import EVMWalletProvider
 from bnbagent.networks import BSC_MAINNET_CHAIN_ID, get_address
 from bnbagent.x402 import (
+    SessionBudgetTracker,
     X402AmountExceededError,
     X402BudgetExhaustedError,
     X402PolicyError,
@@ -139,6 +140,119 @@ def test_rejects_when_value_exceeds_max_per_call(signer):
     with pytest.raises(X402AmountExceededError, match="exceeds max_value_per_call"):
         signer.sign_payment(**p, expected_to=p["message"]["to"])
     assert signer.budget.spent(U_MAINNET) == 0
+
+
+# ── Negative value (SRC-1314) ────────────────────────────────────────────
+# The per-call cap and the session budget are both one-sided comparisons
+# (`value > cap`, `cur + amt > cap`), valid only under a `value >= 0`
+# precondition that nothing used to assert. A negative value slipped past
+# both and drove the session counter negative, neutralising the budget.
+
+
+def test_negative_value_is_rejected(signer):
+    p = _payload(value=-1)
+    with pytest.raises(X402AmountExceededError, match="non-negative"):
+        signer.sign_payment(**p, expected_to=p["message"]["to"])
+    assert signer.budget.spent(U_MAINNET) == 0
+
+
+def test_huge_negative_value_is_rejected(signer):
+    """The exploit's magnitude: large enough to swamp the cap for a session."""
+    p = _payload(value=-(10**30))
+    with pytest.raises(X402AmountExceededError, match="non-negative"):
+        signer.sign_payment(**p, expected_to=p["message"]["to"])
+    assert signer.budget.spent(U_MAINNET) == 0
+
+
+def test_negative_value_via_int256_schema_is_rejected(signer):
+    """The full exploit chain: a poisoned `types` dict declaring `value` as
+    int256 (so eth_abi will happily encode a negative) plus a negative value.
+
+    Both defects had to align — under the canonical uint256 schema eth_abi
+    raises and the rollback path restores the counter, so the corruption was
+    transient. int256 made it persistent *and* produced a real signature.
+    """
+    p = _payload(value=-(10**30), from_addr=signer.wallet_address)
+    p["types"] = {
+        "EIP712Domain": EIP712DOMAIN_FIELDS,
+        "TransferWithAuthorization": [
+            {**f, "type": "int256"} if f["name"] == "value" else f
+            for f in TWA_FIELDS
+        ],
+    }
+    with pytest.raises((X402AmountExceededError, X402PolicyError)):
+        signer.sign_payment(**p, expected_to=p["message"]["to"])
+    assert signer.budget.spent(U_MAINNET) == 0
+
+
+def test_int256_schema_rejected_through_the_x402_path(signer):
+    """Fix C standing alone: a positive, in-cap value with a poisoned schema.
+
+    The amount guards have nothing to object to here, so this only passes if
+    the wallet's SigningPolicy is genuinely reached and pins the field shape —
+    and the budget must be rolled back on the way out.
+    """
+    p = _payload(value=500_000, from_addr=signer.wallet_address)
+    p["types"] = {
+        "EIP712Domain": EIP712DOMAIN_FIELDS,
+        "TransferWithAuthorization": [
+            {**f, "type": "int256"} if f["name"] == "value" else f
+            for f in TWA_FIELDS
+        ],
+    }
+    with pytest.raises(X402PolicyError, match="canonical EIP-3009 field shape"):
+        signer.sign_payment(**p, expected_to=p["message"]["to"])
+    assert signer.budget.spent(U_MAINNET) == 0
+
+
+def test_failed_poison_does_not_authorise_overspend(signer):
+    """The consequence under test, stated directly: a rejected poison attempt
+    must leave the advertised session cap fully enforced.
+    """
+    p = _payload(value=-(10**30), from_addr=signer.wallet_address)
+    with pytest.raises(X402AmountExceededError):
+        signer.sign_payment(**p, expected_to=p["message"]["to"])
+
+    # 5 x 1_000_000 exactly exhausts the 5_000_000 session budget.
+    for _ in range(5):
+        q = _payload(value=1_000_000, from_addr=signer.wallet_address)
+        signer.sign_payment(**q, expected_to=q["message"]["to"])
+    assert signer.budget.spent(U_MAINNET) == 5_000_000
+
+    r = _payload(value=1, from_addr=signer.wallet_address)
+    with pytest.raises(X402BudgetExhaustedError):
+        signer.sign_payment(**r, expected_to=r["message"]["to"])
+
+
+# ── SessionBudgetTracker negative-amount guard (SRC-1314) ────────────────
+# The "counter must never go negative" invariant was installed on rollback()
+# (where it is merely defensive) but not on the increment paths (where it is
+# load-bearing). Assert it directly on the tracker, independent of the signer.
+
+
+def test_tracker_reserve_rejects_negative_amount():
+    t = SessionBudgetTracker({U_MAINNET: 1_000})
+    with pytest.raises(X402BudgetExhaustedError, match="non-negative"):
+        t.reserve(U_MAINNET, -1)
+    assert t.spent(U_MAINNET) == 0
+
+
+def test_tracker_commit_rejects_negative_amount():
+    """commit() is the legacy path but reaches the same counter."""
+    t = SessionBudgetTracker({U_MAINNET: 1_000})
+    with pytest.raises(X402BudgetExhaustedError, match="non-negative"):
+        t.commit(U_MAINNET, -1)
+    assert t.spent(U_MAINNET) == 0
+
+
+def test_tracker_reserve_rejects_negative_even_without_a_cap():
+    """An untracked token has no cap, but the counter must still not go
+    negative — a later extend()/cap change would otherwise inherit the debt.
+    """
+    t = SessionBudgetTracker(None)
+    with pytest.raises(X402BudgetExhaustedError, match="non-negative"):
+        t.reserve(U_MAINNET, -1)
+    assert t.spent(U_MAINNET) == 0
 
 
 # ── Session budget ──────────────────────────────────────────────────────


### PR DESCRIPTION
Fixes bug bounty report **SRC-1314** on the published Python SDK. The TypeScript port of
the same defect is handled separately against `feat-tssdk` (see the companion PR) — this
branch is Python only so the fix to the live release is reviewable on its own.

**This is a fix to a published package.** `bnbagent` 0.4.0 on PyPI contains the vulnerable
code byte-for-byte (`bnbagent/x402/budget.py:97`, `bnbagent/x402/signer.py:163` at
`bnbagent-v0.4.0`).

## Root cause

`value >= 0` was never owned by any guard. The only component enforcing that domain was
`eth_abi`'s encoder — and the encoder's accepted domain is dictated by the
attacker-controlled `types` dict. Measured:

```
uint256 + value=-1e30  ->  REJECTED  ValueOutOfBounds
int256  + value=-1e30  ->  SIGNED
```

So `uint256 -> int256` does not bypass a check; it removes the only one that ever existed.
Three layers each assumed another had it:

1. `X402Signer`'s docstring designates `SigningPolicy` as the *structural* defence, but
   `infer_primary_type` only reads `types.keys()` — it validates the struct **name** and
   never the field list. "Structural" was name-only.
2. L1 coerces with `int()` (widening, not validating) and compares one side (`value > cap`).
3. `SessionBudgetTracker` put "the counter must never go negative" on `rollback()`
   (`max(0, ...)`) instead of `reserve()` — the decrement side, where it is merely
   defensive, rather than the increment side, where it is load-bearing.

**Both defects were required.** Under the canonical `uint256` schema, `reserve()` still
corrupts the counter but `eth_abi` then raises, `except BaseException` catches it,
`rollback()` runs, and the counter returns to exactly 0 — the attack self-heals. Only
`int256` makes the corruption persist *and* yield a real EIP-3009 signature. Two
individually-latent defects, exploitable only in combination — which is why this survived
code review, the unit suite, and the v0.4.1 concurrency audit (the lock does correctly
serialise the operation; serialising wrong arithmetic doesn't help).

## Changes

- **`fix(x402)`** — refuse negative amounts in `reserve()` / `commit()` and at the signer's
  L1, before `reserve()` so rejected calls still cost no budget.
- **`fix(signing)`** — pin name, type, order and count of both EIP-3009 structs against
  their canonical shape. This closes the root cause, not just this instance: the whole
  "attacker-controlled `types` smuggles an unexpected encoding" class. Scoped to structs we
  know canonically, so `permissive()` and custom `extend()` callers are unaffected.
- **`test(x402)`** — 15 tests covering the combination and each half alone, including an
  `int256` schema with a positive in-cap value (rejected on shape alone, proving the pin
  stands without the amount guards), and the consequence stated directly: after a rejected
  poison the advertised session cap is still exactly enforced.

## Verification

Reporter's PoC, unmodified logic, before → after:

```
BEFORE  FAIL - phase A signed; budget corrupted: spent=-1000000000000000000000000000000
        FAIL - phase B: 100 signatures authorised (advertised cap = 5)

AFTER   OK   - phase A refused: X402AmountExceededError: message['value'] must be non-negative
        OK   - budget uncorrupted: spent=0
        OK   - phase B: 5 signatures authorised (advertised cap = 5)
```

`python -m pytest`: 747 passed.

Reported-by: @ahmedbahy816
