### PR TITLE
ci: add the unified npm publish workflow to the default branch

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,683 @@
+name: Publish (npm)
+run-name: Publish @bnbagent/sdk (${{ inputs.release_type }})
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_type:
+        description: "Release channel"
+        required: true
+        default: alpha
+        type: choice
+        options:
+          - alpha
+          - production
+      source_ref:
+        description: "Alpha source branch or commit SHA (ignored for production)"
+        required: false
+        type: string
+      target_version:
+        description: "Alpha target stable version (X.Y.Z)"
+        required: true
+        default: "0.5.0"
+        type: string
+      existing_version:
+        description: "Existing alpha version to verify without republishing (optional)"
+        required: false
+        type: string
+      bump:
+        description: "Production version selection (current is for the first 0.5.0 release)"
+        required: true
+        default: current
+        type: choice
+        options:
+          - current
+          - patch
+          - minor
+          - major
+
+permissions:
+  actions: read
+  contents: read
+
+concurrency:
+  group: npm-publish
+  cancel-in-progress: false
+
+jobs:
+  validate:
+    name: Validate protected dispatch
+    runs-on: ubuntu-latest
+    steps:
+      - name: Require the default-branch workflow
+        env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
+          REF_NAME: ${{ github.ref_name }}
+          RELEASE_TYPE: ${{ inputs.release_type }}
+          SOURCE_REF: ${{ inputs.source_ref }}
+        run: |
+          set -euo pipefail
+          if [[ "$REF_NAME" != "$DEFAULT_BRANCH" ]]; then
+            echo "Run this workflow from the protected default branch: $DEFAULT_BRANCH" >&2
+            exit 1
+          fi
+          if [[ "$RELEASE_TYPE" == "alpha" && -z "$SOURCE_REF" ]]; then
+            echo "source_ref is required for an alpha release" >&2
+            exit 1
+          fi
+
+  resolve:
+    name: Resolve source, version, and CI evidence
+    if: inputs.release_type == 'alpha'
+    needs: validate
+    runs-on: ubuntu-latest
+    outputs:
+      alpha_version: ${{ steps.version.outputs.alpha_version }}
+      ci_run_url: ${{ steps.ci.outputs.ci_run_url }}
+      reuse_ci: ${{ steps.ci.outputs.reuse_ci }}
+      source_sha: ${{ steps.version.outputs.source_sha }}
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Checkout alpha source
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.source_ref }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+
+      - name: Resolve the next alpha version
+        id: version
+        env:
+          EXISTING_VERSION: ${{ inputs.existing_version }}
+          TARGET_VERSION: ${{ inputs.target_version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TARGET_VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "target_version must be X.Y.Z, got: $TARGET_VERSION" >&2
+            exit 1
+          fi
+
+          PACKAGE_NAME="$(node -p "require('./package.json').name")"
+          if [[ "$PACKAGE_NAME" != "@bnbagent/sdk" ]]; then
+            echo "Refusing to publish unexpected package: $PACKAGE_NAME" >&2
+            exit 1
+          fi
+
+          STABLE_VERSION="$(npm view "$PACKAGE_NAME@$TARGET_VERSION" version 2>/dev/null || true)"
+          if [[ "$STABLE_VERSION" == "$TARGET_VERSION" ]]; then
+            echo "Refusing to publish an alpha after stable $TARGET_VERSION" >&2
+            exit 1
+          fi
+
+          SOURCE_SHA="$(git rev-parse HEAD)"
+          ALPHA_VERSION="$(
+            node <<'NODE'
+          const { execFileSync } = require("node:child_process");
+
+          const packageName = "@bnbagent/sdk";
+          const target = process.env.TARGET_VERSION;
+          const existing = process.env.EXISTING_VERSION;
+
+          function versions() {
+            try {
+              const output = execFileSync(
+                "npm",
+                ["view", packageName, "versions", "--json"],
+                {
+                  encoding: "utf8",
+                  stdio: ["ignore", "pipe", "pipe"],
+                },
+              );
+              const parsed = JSON.parse(output || "[]");
+              return Array.isArray(parsed)
+                ? parsed
+                : typeof parsed === "string"
+                  ? [parsed]
+                  : [];
+            } catch (error) {
+              const stderr = String(error.stderr || "");
+              if (stderr.includes("E404")) return [];
+              throw error;
+            }
+          }
+
+          function alphaTag() {
+            try {
+              const output = execFileSync("npm", ["dist-tag", "ls", packageName], {
+                encoding: "utf8",
+                stdio: ["ignore", "pipe", "pipe"],
+              });
+              return output.match(/^alpha:\s+(\S+)$/m)?.[1];
+            } catch (error) {
+              const stderr = String(error.stderr || "");
+              if (stderr.includes("E404")) return undefined;
+              throw error;
+            }
+          }
+
+          const published = new Set(versions());
+          const tagged = alphaTag();
+          if (tagged) published.add(tagged);
+
+          if (existing) {
+            const pattern = new RegExp(`^${target.replace(/\./g, "\\.")}-alpha\\.[0-9]+$`);
+            if (!pattern.test(existing)) {
+              throw new Error(`existing_version must match ${target}-alpha.N`);
+            }
+            if (!published.has(existing)) {
+              throw new Error(`existing_version is not published: ${existing}`);
+            }
+            process.stdout.write(existing);
+            process.exit(0);
+          }
+
+          const prefix = `${target}-alpha.`;
+          const numbers = [...published]
+            .filter((version) => version.startsWith(prefix))
+            .map((version) => version.slice(prefix.length))
+            .filter((suffix) => /^\d+$/.test(suffix))
+            .map(Number);
+          process.stdout.write(`${prefix}${Math.max(0, ...numbers) + 1}`);
+          NODE
+          )"
+
+          echo "alpha_version=$ALPHA_VERSION" >> "$GITHUB_OUTPUT"
+          echo "source_sha=$SOURCE_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Reuse trusted CI for the exact source commit
+        id: ci
+        env:
+          GH_TOKEN: ${{ github.token }}
+          SOURCE_SHA: ${{ steps.version.outputs.source_sha }}
+          TRUSTED_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          echo "reuse_ci=false" >> "$GITHUB_OUTPUT"
+          echo "ci_run_url=" >> "$GITHUB_OUTPUT"
+
+          if ! RUNS="$(
+            gh api --method GET \
+              "repos/$GITHUB_REPOSITORY/actions/workflows/typescript-ci.yml/runs" \
+              -f head_sha="$SOURCE_SHA" \
+              -f status=success \
+              -f per_page=10
+          )"; then
+            echo "::warning::Could not read CI evidence; running fresh verification"
+            exit 0
+          fi
+
+          while read -r RUN_ID; do
+            [[ -n "$RUN_ID" ]] || continue
+            if ! JOBS="$(gh api "repos/$GITHUB_REPOSITORY/actions/runs/$RUN_ID/jobs")"; then
+              continue
+            fi
+            if jq -e '
+              def passed($steps; $name):
+                any($steps[]?; .name == $name and .conclusion == "success");
+              any(
+                .jobs[];
+                .name == "check"
+                  and .conclusion == "success"
+                  and (
+                    .steps as $steps
+                    | passed($steps; "Regenerate ABIs and verify no drift")
+                      and passed($steps; "Typecheck (src)")
+                      and passed($steps; "Typecheck (examples)")
+                      and passed($steps; "Lint")
+                      and passed($steps; "Test")
+                      and passed($steps; "Build")
+                      and passed($steps; "Offline examples (self-contained, no network)")
+                  )
+              )
+            ' <<<"$JOBS" >/dev/null; then
+              echo "reuse_ci=true" >> "$GITHUB_OUTPUT"
+              echo "ci_run_url=https://github.com/$GITHUB_REPOSITORY/actions/runs/$RUN_ID" \
+                >> "$GITHUB_OUTPUT"
+              echo "Reusing successful CI run $RUN_ID for $SOURCE_SHA"
+              exit 0
+            fi
+          done < <(
+            jq -r \
+              --arg branch "$TRUSTED_BRANCH" \
+              --arg sha "$SOURCE_SHA" \
+              '
+                .workflow_runs[]
+                | select(
+                    .event == "push"
+                    and .head_branch == $branch
+                    and .head_sha == $sha
+                    and .path == ".github/workflows/typescript-ci.yml"
+                  )
+                | .id
+              ' <<<"$RUNS"
+          )
+
+          echo "No reusable trusted-branch CI run found for $SOURCE_SHA; running fresh verification"
+
+  verify:
+    name: Verify source (${{ matrix.check }})
+    if: inputs.release_type == 'alpha' && needs.resolve.outputs.reuse_ci != 'true'
+    needs: resolve
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        check:
+          - static
+          - tests
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Checkout the resolved source commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: typescript/package.json
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: typescript/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run verification slice
+        env:
+          CHECK: ${{ matrix.check }}
+        run: |
+          set -euo pipefail
+          case "$CHECK" in
+            static)
+              pnpm run codegen
+              git diff --exit-code src/abis
+
+              PIDS=()
+              pnpm run typecheck &
+              PIDS+=("$!")
+              pnpm run typecheck:examples &
+              PIDS+=("$!")
+              pnpm run lint &
+              PIDS+=("$!")
+
+              FAILED=0
+              for PID in "${PIDS[@]}"; do
+                if ! wait "$PID"; then
+                  FAILED=1
+                fi
+              done
+              if [[ "$FAILED" -ne 0 ]]; then
+                exit 1
+              fi
+              git diff --check
+              ;;
+            tests)
+              pnpm run test
+              ;;
+            *)
+              echo "Unknown verification slice: $CHECK" >&2
+              exit 1
+              ;;
+          esac
+
+  package:
+    name: Build and verify the alpha tarball
+    if: inputs.release_type == 'alpha'
+    needs: resolve
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Checkout the resolved source commit
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.resolve.outputs.source_sha }}
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: typescript/package.json
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: typescript/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Apply the alpha version and build once
+        env:
+          ALPHA_VERSION: ${{ needs.resolve.outputs.alpha_version }}
+        run: |
+          npm pkg set "version=$ALPHA_VERSION"
+          pnpm run build
+          git diff --check
+
+      - name: Run offline examples
+        run: |
+          set -euo pipefail
+          pnpm run example:x402 &
+          X402_PID="$!"
+          pnpm run example:security &
+          SECURITY_PID="$!"
+
+          FAILED=0
+          for PID in "$X402_PID" "$SECURITY_PID"; do
+            if ! wait "$PID"; then
+              FAILED=1
+            fi
+          done
+          exit "$FAILED"
+
+      - name: Pack and verify the installable tarball
+        env:
+          ALPHA_VERSION: ${{ needs.resolve.outputs.alpha_version }}
+        run: |
+          set -euo pipefail
+          PACK_DIR="$RUNNER_TEMP/npm-pack"
+          CONSUMER_DIR="$(mktemp -d)"
+          mkdir -p "$PACK_DIR"
+          npm pack --json --pack-destination "$PACK_DIR" >/dev/null
+          mapfile -t TARBALLS < <(find "$PACK_DIR" -maxdepth 1 -type f -name '*.tgz')
+          if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
+            echo "Expected exactly one tarball, found ${#TARBALLS[@]}" >&2
+            exit 1
+          fi
+          TARBALL_PATH="$PACK_DIR/bnbagent-sdk-$ALPHA_VERSION.tgz"
+          if [[ "${TARBALLS[0]}" != "$TARBALL_PATH" ]]; then
+            echo "Unexpected tarball filename: ${TARBALLS[0]}" >&2
+            exit 1
+          fi
+          tar -xOf "$TARBALL_PATH" package/package.json |
+            jq -e --arg version "$ALPHA_VERSION" \
+              '.name == "@bnbagent/sdk" and .version == $version' >/dev/null
+
+          cd "$CONSUMER_DIR"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund "$TARBALL_PATH"
+          node --input-type=module -e \
+            "await import('@bnbagent/sdk'); const { getBuiltWithValue } = await import('@bnbagent/sdk/erc8004'); const expected = 'https://github.com/bnb-chain/bnbagent-sdk#v' + process.env.ALPHA_VERSION; if (getBuiltWithValue() !== expected) throw new Error('unexpected built_with version')"
+          node -e \
+            "require('@bnbagent/sdk'); require('@bnbagent/sdk/erc8004')"
+
+      - name: Upload verified tarball
+        uses: actions/upload-artifact@v4
+        with:
+          name: bnbagent-sdk-${{ needs.resolve.outputs.alpha_version }}
+          path: ${{ runner.temp }}/npm-pack/*.tgz
+          if-no-files-found: error
+          retention-days: 7
+
+  alpha-publish:
+    name: Publish alpha to npm
+    if: >-
+      always() &&
+      inputs.release_type == 'alpha' &&
+      needs.resolve.result == 'success' &&
+      needs.package.result == 'success' &&
+      (needs.verify.result == 'success' || needs.verify.result == 'skipped')
+    needs:
+      - resolve
+      - verify
+      - package
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - name: Download verified tarball
+        uses: actions/download-artifact@v4
+        with:
+          name: bnbagent-sdk-${{ needs.resolve.outputs.alpha_version }}
+          path: package
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+
+      - name: Install OIDC-capable npm
+        run: npm install --global npm@11.15.0
+
+      - name: Verify artifact identity
+        id: artifact
+        env:
+          ALPHA_VERSION: ${{ needs.resolve.outputs.alpha_version }}
+        run: |
+          set -euo pipefail
+          # Absolute path: npm parses a bare "package/x.tgz" argument as a
+          # GitHub owner/repo shorthand, not a file.
+          mapfile -t TARBALLS < <(find "$PWD/package" -maxdepth 1 -type f -name '*.tgz')
+          if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
+            echo "Expected exactly one tarball, found ${#TARBALLS[@]}" >&2
+            exit 1
+          fi
+          TARBALL="$PWD/package/bnbagent-sdk-$ALPHA_VERSION.tgz"
+          if [[ "${TARBALLS[0]}" != "$TARBALL" ]]; then
+            echo "Unexpected tarball filename: ${TARBALLS[0]}" >&2
+            exit 1
+          fi
+          tar -xOf "$TARBALL" package/package.json |
+            jq -e --arg version "$ALPHA_VERSION" \
+              '.name == "@bnbagent/sdk" and .version == $version' >/dev/null
+          echo "tarball=$TARBALL" >> "$GITHUB_OUTPUT"
+
+      - name: Read registry state
+        id: registry
+        env:
+          ALPHA_VERSION: ${{ needs.resolve.outputs.alpha_version }}
+        run: |
+          set -euo pipefail
+          TAGS="$(npm dist-tag ls "@bnbagent/sdk" 2>/dev/null || true)"
+          ALPHA_TAG="$(awk '$1 == "alpha:" { print $2 }' <<<"$TAGS")"
+          LATEST_TAG="$(awk '$1 == "latest:" { print $2 }' <<<"$TAGS")"
+
+          if [[ "$ALPHA_TAG" == "$ALPHA_VERSION" ]]; then
+            EXISTS=true
+          else
+            EXACT="$(
+              npm view "@bnbagent/sdk@$ALPHA_VERSION" version --prefer-online 2>/dev/null || true
+            )"
+            if [[ "$EXACT" == "$ALPHA_VERSION" ]]; then
+              EXISTS=true
+            else
+              EXISTS=false
+            fi
+          fi
+
+          echo "exists=$EXISTS" >> "$GITHUB_OUTPUT"
+          echo "latest=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Publish under the alpha dist-tag
+        if: steps.registry.outputs.exists != 'true'
+        env:
+          # workflow_dispatch runs from main while source_ref may be another
+          # commit, so alpha provenance would identify the dispatcher commit.
+          NPM_CONFIG_PROVENANCE: "false"
+        run: >-
+          npm publish "${{ steps.artifact.outputs.tarball }}"
+          --access public
+          --tag alpha
+          --ignore-scripts
+          --json
+
+      - name: Check prerelease dist-tags
+        env:
+          ALPHA_VERSION: ${{ needs.resolve.outputs.alpha_version }}
+          PREVIOUS_LATEST: ${{ steps.registry.outputs.latest }}
+        run: |
+          set -euo pipefail
+          TAGS="$(npm dist-tag ls "@bnbagent/sdk" 2>/dev/null || true)"
+          ALPHA_TAG="$(awk '$1 == "alpha:" { print $2 }' <<<"$TAGS")"
+          LATEST_TAG="$(awk '$1 == "latest:" { print $2 }' <<<"$TAGS")"
+
+          if [[ "$ALPHA_TAG" != "$ALPHA_VERSION" ]]; then
+            echo "::warning::npm accepted the publish, but the public alpha tag is still propagating"
+          fi
+          if [[ "$LATEST_TAG" == "$ALPHA_VERSION" ]]; then
+            echo "Refusing to leave an alpha version under latest" >&2
+            exit 1
+          fi
+          if [[ -n "$PREVIOUS_LATEST" && "$LATEST_TAG" != "$PREVIOUS_LATEST" ]]; then
+            echo "latest changed from $PREVIOUS_LATEST to $LATEST_TAG" >&2
+            exit 1
+          fi
+
+      - name: Check public metadata without blocking publication
+        env:
+          ALPHA_VERSION: ${{ needs.resolve.outputs.alpha_version }}
+        run: |
+          EXACT="$(
+            npm view "@bnbagent/sdk@$ALPHA_VERSION" version 2>/dev/null || true
+          )"
+          if [[ "$EXACT" != "$ALPHA_VERSION" ]]; then
+            echo "::warning::@bnbagent/sdk@$ALPHA_VERSION is published but public metadata is still propagating"
+          fi
+
+      - name: Write install summary
+        env:
+          ALPHA_VERSION: ${{ needs.resolve.outputs.alpha_version }}
+          CI_RUN_URL: ${{ needs.resolve.outputs.ci_run_url }}
+          REUSE_CI: ${{ needs.resolve.outputs.reuse_ci }}
+          SOURCE_SHA: ${{ needs.resolve.outputs.source_sha }}
+        run: |
+          {
+            echo "## @bnbagent/sdk alpha package"
+            echo
+            echo "- Version: \`$ALPHA_VERSION\`"
+            echo "- Source commit: \`$SOURCE_SHA\`"
+            if [[ "$REUSE_CI" == "true" ]]; then
+              echo "- Verification: reused [successful CI]($CI_RUN_URL) for the exact source commit"
+            else
+              echo "- Verification: fresh parallel checks in this workflow"
+            fi
+            echo "- Dist-tag: \`alpha\`"
+            echo "- Provenance: disabled because source_ref may differ from the dispatcher commit"
+            echo
+            echo '```bash'
+            echo "pnpm add -E @bnbagent/sdk@$ALPHA_VERSION"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  production:
+    name: Publish production to npm
+    if: inputs.release_type == 'production'
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: npm-publish
+    permissions:
+      contents: write
+      id-token: write
+    defaults:
+      run:
+        working-directory: typescript
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: typescript/package.json
+
+      - name: Setup Node 24
+        uses: actions/setup-node@v4
+        with:
+          node-version: "24"
+          registry-url: https://registry.npmjs.org
+          cache: pnpm
+          cache-dependency-path: typescript/pnpm-lock.yaml
+
+      - name: Install OIDC-capable npm
+        run: npm install --global npm@11.15.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Verify ABIs are in sync
+        run: |
+          pnpm run codegen
+          git diff --exit-code src/abis
+
+      - name: Check source and build
+        run: |
+          pnpm run typecheck
+          pnpm run typecheck:examples
+          pnpm run lint
+          pnpm run test
+          pnpm run build
+          git diff --check
+
+      - name: Prepare or resume version
+        id: version
+        run: pnpm exec tsx scripts/release.ts prepare "${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
+
+      - name: Generate release notes
+        run: pnpm exec tsx scripts/release.ts changelog > RELEASE_NOTES.md
+
+      - name: Commit version bump through the GitHub API
+        if: steps.version.outputs.commit == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          V: ${{ steps.version.outputs.version }}
+        run: pnpm exec tsx scripts/release.ts commit "$V"
+
+      - name: Freeze workspace dependencies for publishing
+        run: pnpm exec tsx scripts/release.ts freeze
+
+      - name: Package smoke test
+        run: pnpm exec tsx scripts/release.ts pack
+
+      - name: Publish stable package with provenance
+        run: pnpm exec tsx scripts/release.ts publish --tag latest
+
+      - name: Create Git tag and GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          V: ${{ steps.version.outputs.version }}
+        run: >-
+          gh release create "v$V"
+          --target "${{ github.event.repository.default_branch }}"
+          --title "v$V"
+          --notes-file RELEASE_NOTES.md
+
+      - name: Write release summary
+        env:
+          V: ${{ steps.version.outputs.version }}
+        run: |
+          {
+            echo "## @bnbagent/sdk production package"
+            echo
+            echo "- Version: \`$V\`"
+            echo "- Dist-tag: \`latest\`"
+            echo "- GitHub Release: \`v$V\`"
+            echo "- Provenance: enabled by npm trusted publishing"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

`workflow_dispatch` workflows are only registered from the default branch, and this workflow additionally guards `github.ref_name == default_branch`. It currently exists only on `feat-tssdk` (added there by #62/#63), so today **neither channel is reachable**:

- `gh workflow run npm-publish.yml --ref main` → 404, the file is not on `main`
- `gh workflow run ... --ref feat-tssdk` → the default-branch guard fails the run

The last alpha (`0.5.0-alpha.1`, 2026-07-29) predates #63 and was dispatched while the same workflow still sat at the registered `npm-qa.yml` path. After the rename that handle no longer exists.

This mirrors what `bnbagent-studio` already did in bnb-chain/bnbagent-studio#35.

## What

Adds `.github/workflows/npm-publish.yml` exactly as it stands on `feat-tssdk` — no content changes.

`npm-qa.yml` is deliberately left in place so the `qa` channel keeps working on `main`; it is already absent from `feat-tssdk` and disappears when that branch lands.

## After merge

    gh workflow run npm-publish.yml --ref main \
      -f release_type=alpha -f source_ref=feat-tssdk -f target_version=0.5.0

Expected: `0.5.0-alpha.2` under dist-tag `alpha`.