### PR TITLE
feat: harden MegaFuel relay observability (BUG-029 follow-up)

### DIFF
--- a/typescript/src/core/paymaster.ts
+++ b/typescript/src/core/paymaster.ts
@@ -8,8 +8,26 @@
  */
 
 import { bytesToHex, getAddress, numberToHex } from "viem";
+import { RelayRejectedError } from "../errors.js";
 
 const RPC_TIMEOUT_MS = 30_000;
+
+/**
+ * Internal typed wrapper for paymaster request failures, so callers that
+ * need to classify (send vs read paths) can branch on `kind` instead of
+ * parsing messages. Messages are kept identical to the previous plain
+ * `Error`s.
+ */
+class PaymasterRequestError extends Error {
+  constructor(
+    message: string,
+    public readonly kind: "rpc" | "http",
+    public readonly code?: number,
+  ) {
+    super(message);
+    this.name = "PaymasterRequestError";
+  }
+}
 
 /** Shape of the transaction fields `isSponsorable` inspects. */
 export interface SponsorableTx {
@@ -159,8 +177,10 @@ export class Paymaster {
     }
 
     if (!response.ok) {
-      throw new Error(
+      throw new PaymasterRequestError(
         `HTTP error ${response.status}${response.statusText ? `: ${response.statusText}` : ""}`,
+        "http",
+        response.status,
       );
     }
 
@@ -173,7 +193,11 @@ export class Paymaster {
       if (result.error.data) {
         console.error(`Error data: ${JSON.stringify(result.error.data)}`);
       }
-      throw new Error(`RPC error [${errorCode}]: ${errorMsg}`);
+      throw new PaymasterRequestError(
+        `RPC error [${errorCode}]: ${errorMsg}`,
+        "rpc",
+        errorCode,
+      );
     }
 
     return result;
@@ -229,15 +253,36 @@ export class Paymaster {
       ? signedTransaction
       : `0x${signedTransaction}`;
 
-    const result = await this.makeRpcRequest(
-      "eth_sendRawTransaction",
-      [prefixed],
-      { headers: txOptions },
-    );
+    let result: JsonRpcResponse;
+    try {
+      result = await this.makeRpcRequest("eth_sendRawTransaction", [prefixed], {
+        headers: txOptions,
+      });
+    } catch (error) {
+      // A JSON-RPC error is the relay explicitly refusing the submission:
+      // no nonce was consumed, so callers may safely retry or self-pay
+      // (definite). An HTTP/transport failure is ambiguous — the tx may or
+      // may not have entered the relay queue — so it must never trigger an
+      // automatic re-send (definite: false).
+      if (error instanceof PaymasterRequestError && error.kind === "rpc") {
+        throw new RelayRejectedError(error.message, true, {
+          rpcErrorCode: error.code,
+          cause: error,
+        });
+      }
+      throw new RelayRejectedError(
+        error instanceof Error ? error.message : String(error),
+        false,
+        { cause: error },
+      );
+    }
 
     const txHash = result.result;
     if (txHash === undefined || txHash === null) {
-      throw new Error("Failed to send raw transaction: missing 'result' field");
+      throw new RelayRejectedError(
+        "Failed to send raw transaction: missing 'result' field",
+        false,
+      );
     }
     return txHash as string;
   }

--- a/typescript/src/core/relayVerifier.ts
+++ b/typescript/src/core/relayVerifier.ts
@@ -1,0 +1,203 @@
+/**
+ * Secondary confirmation that a relay-returned tx hash is really invisible.
+ *
+ * The MegaFuel relay failure mode behind `RelaySubmissionUnverifiedError` is
+ * "relay accepted a hash the chain never saw". Before a caller reacts to that
+ * (e.g. re-signing the same nonce as a self-paid transaction), it is worth a
+ * few seconds to ask *other* RPC endpoints whether the transaction is truly
+ * unseen — a flaky primary RPC must not trigger a same-nonce race against a
+ * transaction that actually reached the mempool.
+ *
+ * Degradation is deliberate: when every fallback endpoint errors out the
+ * result is `"inconclusive"`, and callers keep their existing behavior. The
+ * self-pay safety net must never depend on third-party RPC availability.
+ */
+
+import {
+  BSC_MAINNET_CHAIN_ID,
+  BSC_TESTNET_CHAIN_ID,
+} from "../networks/addresses.js";
+import { getEnv } from "./envUtil.js";
+
+/** Outcome of probing a single RPC endpoint for a transaction. */
+export type TxProbeResult = "seen" | "unseen" | "error";
+
+/**
+ * Aggregate verdict across all fallback endpoints:
+ * - `"seen"` — at least one endpoint can see the transaction; it reached the
+ *   network and MUST NOT be treated as unverified.
+ * - `"confirmed-unseen"` — no endpoint saw it and at least one answered
+ *   authoritatively; the relay-dropped diagnosis is corroborated.
+ * - `"inconclusive"` — no usable endpoint or every probe errored; callers
+ *   should keep their pre-existing behavior.
+ */
+export type SecondaryConfirmation =
+  | "confirmed-unseen"
+  | "seen"
+  | "inconclusive";
+
+/** Injectable probe seam (tests replace the raw-fetch default). */
+export type TxPresenceProbe = (
+  rpcUrl: string,
+  hash: `0x${string}`,
+  timeoutMs: number,
+) => Promise<TxProbeResult>;
+
+/** Options for {@link confirmTxUnseen}. */
+export interface RelayVerifierOpts {
+  chainId: number;
+  /** The RPC the primary client already polled — deduped from the fallbacks. */
+  primaryRpcUrl?: string;
+  /** Explicit fallback endpoints; overrides env and the built-in table. */
+  fallbackRpcUrls?: string[] | null;
+  /** Probe implementation; defaults to a raw `eth_getTransactionByHash` fetch. */
+  probe?: TxPresenceProbe;
+  /** Per-endpoint timeout (ms). */
+  perEndpointTimeoutMs?: number;
+}
+
+/** Default per-endpoint probe timeout (ms). */
+export const RELAY_VERIFIER_ENDPOINT_TIMEOUT_MS = 3_000;
+
+/**
+ * Built-in public fallback endpoints per chain. Deliberately module-local:
+ * these are last-resort defaults, overridable via
+ * `BNBAGENT_FALLBACK_RPC_URLS` (comma-separated) or
+ * {@link RelayVerifierOpts.fallbackRpcUrls}.
+ */
+const FALLBACK_RPC_URLS: Record<number, string[]> = {
+  [BSC_TESTNET_CHAIN_ID]: [
+    "https://bsc-testnet-rpc.publicnode.com",
+    "https://data-seed-prebsc-1-s1.bnbchain.org:8545",
+    "https://data-seed-prebsc-2-s1.bnbchain.org:8545",
+  ],
+  [BSC_MAINNET_CHAIN_ID]: [
+    "https://bsc-rpc.publicnode.com",
+    "https://bsc-dataseed1.bnbchain.org",
+    "https://bsc-dataseed2.bnbchain.org",
+  ],
+};
+
+/**
+ * Resolve the fallback endpoints to probe: explicit opts, then the
+ * `BNBAGENT_FALLBACK_RPC_URLS` env var, then the built-in per-chain table —
+ * always minus the primary RPC (probing it again adds no information).
+ */
+export function resolveFallbackRpcUrls(
+  opts: Pick<
+    RelayVerifierOpts,
+    "chainId" | "primaryRpcUrl" | "fallbackRpcUrls"
+  >,
+): string[] {
+  let urls: string[];
+  if (opts.fallbackRpcUrls && opts.fallbackRpcUrls.length > 0) {
+    urls = opts.fallbackRpcUrls;
+  } else {
+    const raw = getEnv("BNBAGENT_FALLBACK_RPC_URLS");
+    if (raw !== undefined && raw.trim() !== "") {
+      urls = raw.split(",");
+    } else {
+      urls = FALLBACK_RPC_URLS[opts.chainId] ?? [];
+    }
+  }
+  const primary = normalizeRpcUrl(opts.primaryRpcUrl);
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const entry of urls) {
+    const trimmed = entry.trim();
+    if (trimmed === "") {
+      continue;
+    }
+    const key = normalizeRpcUrl(trimmed);
+    if (key === primary || seen.has(key)) {
+      continue;
+    }
+    seen.add(key);
+    out.push(trimmed);
+  }
+  return out;
+}
+
+/**
+ * Ask the fallback RPC endpoints (in parallel) whether `hash` is visible.
+ *
+ * Never rejects. See {@link SecondaryConfirmation} for the verdict semantics;
+ * "no seen + at least one unseen" is graded `"confirmed-unseen"` even when
+ * other endpoints errored — a single authoritative "not found" is already
+ * more signal than the primary RPC alone provided.
+ */
+export async function confirmTxUnseen(
+  hash: `0x${string}`,
+  opts: RelayVerifierOpts,
+): Promise<SecondaryConfirmation> {
+  const urls = resolveFallbackRpcUrls(opts);
+  if (urls.length === 0) {
+    return "inconclusive";
+  }
+  const probe = opts.probe ?? fetchTxPresence;
+  const timeoutMs =
+    opts.perEndpointTimeoutMs ?? RELAY_VERIFIER_ENDPOINT_TIMEOUT_MS;
+  const results = await Promise.all(
+    urls.map(async (url): Promise<TxProbeResult> => {
+      try {
+        return await probe(url, hash, timeoutMs);
+      } catch {
+        return "error";
+      }
+    }),
+  );
+  if (results.includes("seen")) {
+    return "seen";
+  }
+  if (results.includes("unseen")) {
+    return "confirmed-unseen";
+  }
+  return "inconclusive";
+}
+
+/**
+ * Default probe: a single raw `eth_getTransactionByHash` JSON-RPC call via
+ * `fetch`, bounded by `timeoutMs`. A `null` result is an authoritative
+ * "unseen"; transport failures, non-2xx responses, and RPC errors are all
+ * `"error"` (that endpoint contributes no signal).
+ */
+async function fetchTxPresence(
+  rpcUrl: string,
+  hash: `0x${string}`,
+  timeoutMs: number,
+): Promise<TxProbeResult> {
+  try {
+    const response = await fetch(rpcUrl, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "eth_getTransactionByHash",
+        params: [hash],
+      }),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) {
+      return "error";
+    }
+    const payload = (await response.json()) as {
+      result?: unknown;
+      error?: unknown;
+    };
+    if (payload.error !== undefined && payload.error !== null) {
+      return "error";
+    }
+    if (payload.result === null) {
+      return "unseen";
+    }
+    return payload.result !== undefined ? "seen" : "error";
+  } catch {
+    return "error";
+  }
+}
+
+/** Canonical form for URL dedup: lowercase, no trailing slash. */
+function normalizeRpcUrl(url: string | undefined): string {
+  return (url ?? "").trim().toLowerCase().replace(/\/+$/, "");
+}

--- a/typescript/src/core/txConfig.ts
+++ b/typescript/src/core/txConfig.ts
@@ -46,8 +46,17 @@ export const DEFAULT_GAS_FALLBACK = 2_000_000n;
  */
 export const DEFAULT_RECEIPT_TIMEOUT = 300;
 
+/**
+ * Default seconds a relay-returned tx hash may stay invisible to the chain
+ * RPC before the receipt wait aborts early with
+ * `RelaySubmissionUnverifiedError` instead of holding the caller for the full
+ * receipt timeout. Presence is probed every `RECEIPT_POLL_INTERVAL_MS * 4`.
+ */
+export const DEFAULT_RELAY_UNSEEN_TIMEOUT = 30;
+
 let minGasPriceOverride: bigint | null = null;
 let receiptTimeoutOverride: number | null = null;
+let relayUnseenTimeoutOverride: number | null = null;
 
 /**
  * Pin the gas-price floor (wei) for *all* chains.
@@ -127,10 +136,53 @@ export function getDefaultReceiptTimeout(): number {
   return DEFAULT_RECEIPT_TIMEOUT;
 }
 
-/** Reset both overrides to unset. Test-only. */
+/**
+ * Set the default relay-unseen abort timeout (seconds) for sponsored write
+ * paths. `0` disables the early abort entirely — the wait then runs to the
+ * full receipt timeout regardless of transaction visibility.
+ *
+ * Takes precedence over the `BNBAGENT_RELAY_UNSEEN_TIMEOUT` env var and is
+ * resolved lazily at execute time, like the receipt timeout.
+ *
+ * @throws {Error} `"relay unseen timeout must be >= 0"` if `seconds < 0`.
+ */
+export function setRelayUnseenTimeout(seconds: number): void {
+  if (seconds < 0) {
+    throw new Error("relay unseen timeout must be >= 0");
+  }
+  relayUnseenTimeoutOverride = Math.trunc(seconds);
+}
+
+/**
+ * Resolve the default relay-unseen abort timeout (seconds).
+ *
+ * Precedence: the {@link setRelayUnseenTimeout} override, then the
+ * `BNBAGENT_RELAY_UNSEEN_TIMEOUT` env var, then
+ * {@link DEFAULT_RELAY_UNSEEN_TIMEOUT}. A value of `0` disables the early
+ * abort.
+ */
+export function getRelayUnseenTimeout(): number {
+  if (relayUnseenTimeoutOverride !== null) {
+    return relayUnseenTimeoutOverride;
+  }
+  const raw = getEnv("BNBAGENT_RELAY_UNSEEN_TIMEOUT");
+  if (raw !== undefined) {
+    const parsed = parseIntStrict(raw);
+    if (parsed !== null && parsed >= 0) {
+      return parsed;
+    }
+    console.warn(
+      `Ignoring invalid BNBAGENT_RELAY_UNSEEN_TIMEOUT=${JSON.stringify(raw)}`,
+    );
+  }
+  return DEFAULT_RELAY_UNSEEN_TIMEOUT;
+}
+
+/** Reset all overrides to unset. Test-only. */
 export function _resetTxConfigOverrides(): void {
   minGasPriceOverride = null;
   receiptTimeoutOverride = null;
+  relayUnseenTimeoutOverride = null;
 }
 
 /** Parse a strict base-10 integer string to a `bigint`, or `null` if invalid. */

--- a/typescript/src/core/txSender.ts
+++ b/typescript/src/core/txSender.ts
@@ -25,10 +25,12 @@ import type { WalletProvider } from "../wallets/walletProvider.js";
 import { NonceManager, type NonceManagerClient } from "./nonceManager.js";
 import {
   DEFAULT_GAS_FALLBACK,
+  DEFAULT_RELAY_UNSEEN_TIMEOUT,
   MAX_RETRIES,
   MIN_GAS_PRICE_WEI,
   RETRY_BASE_DELAY,
   getDefaultReceiptTimeout,
+  getRelayUnseenTimeout,
   minGasPriceWei,
 } from "./txConfig.js";
 
@@ -50,8 +52,13 @@ export const RECEIPT_POLL_INTERVAL_MS = 250;
  * probed every `RECEIPT_POLL_INTERVAL_MS * 4`, so this window allows ~30
  * probes — ample for relay broadcast + mempool propagation; a relay that
  * silently dropped the tx is detected in seconds rather than minutes.
+ *
+ * @deprecated Use {@link DEFAULT_RELAY_UNSEEN_TIMEOUT} /
+ * `getRelayUnseenTimeout()` from `txConfig` — the effective default is now
+ * resolved lazily so `setRelayUnseenTimeout()` and the
+ * `BNBAGENT_RELAY_UNSEEN_TIMEOUT` env var take effect.
  */
-export const RELAY_UNSEEN_ABORT_SECONDS = 30;
+export const RELAY_UNSEEN_ABORT_SECONDS = DEFAULT_RELAY_UNSEEN_TIMEOUT;
 
 /** Internal sentinel distinguishing "receipt wait timed out" from any other rejection. */
 export class ReceiptWaitTimeout extends Error {
@@ -326,7 +333,7 @@ export async function waitForReceiptAndInterpret(
     receipt = await waitForReceipt(client, hash, timeoutSeconds, {
       trackTransactionPresence: opts.requireTransactionSeen,
       unseenAbortSeconds: opts.requireTransactionSeen
-        ? (opts.unseenAbortSeconds ?? RELAY_UNSEEN_ABORT_SECONDS)
+        ? (opts.unseenAbortSeconds ?? getRelayUnseenTimeout())
         : undefined,
     });
   } catch (error) {
@@ -334,7 +341,13 @@ export async function waitForReceiptAndInterpret(
       if (opts.requireTransactionSeen && !error.transactionSeen) {
         throw new RelaySubmissionUnverifiedError(hash, error.waitedSeconds);
       }
-      throw new TransactionPendingError(hash, timeoutSeconds);
+      const pending = new TransactionPendingError(hash, timeoutSeconds);
+      if (opts.requireTransactionSeen && error.transactionSeen) {
+        // The RPC saw the tx but it never mined within the full timeout —
+        // likely stuck in the mempool rather than still propagating.
+        pending.relayStatus = "receipt_timeout_but_tx_visible";
+      }
+      throw pending;
     }
     throw error;
   }

--- a/typescript/src/erc8183/jobOps.ts
+++ b/typescript/src/erc8183/jobOps.ts
@@ -29,6 +29,7 @@ import type { NetworkConfig } from "../config.js";
 import { getEnv } from "../core/envUtil.js";
 import { describeError } from "../core/txSender.js";
 import {
+  RelayRejectedError,
   RelaySubmissionUnverifiedError,
   RpcRangeLimitError,
   TransactionPendingError,
@@ -155,6 +156,7 @@ export const ERR_INTERNAL = "internal_error"; // unexpected failure (retryable)
 export const ERR_CHAIN_UNAVAILABLE = "chain_unavailable"; // transient chain/RPC trouble (retryable)
 export const ERR_TX_PENDING = "tx_pending"; // tx broadcast but unconfirmed (NOT retryable)
 export const ERR_TX_UNVERIFIED = "tx_unverified"; // relay hash not observed (NOT blindly retryable)
+export const ERR_RELAY_REJECTED = "relay_rejected"; // relay refused the submission (retryable only when definite)
 
 /**
  * Safe `{ error, error_code }` fields for an exception.
@@ -188,6 +190,20 @@ export function excErrorFields(exc: unknown): Record<string, unknown> {
       error_code: ERR_TX_UNVERIFIED,
       retryable: false,
       tx_hash: exc.txHash,
+    };
+  }
+
+  if (exc instanceof RelayRejectedError) {
+    // A definite rejection consumed no nonce, so a retry is safe. An
+    // ambiguous (definite=false) failure may have entered the relay queue —
+    // treat it like an unverified submission: no blind retry.
+    return {
+      error: exc.message,
+      error_code: ERR_RELAY_REJECTED,
+      retryable: exc.definite,
+      ...(exc.rpcErrorCode !== undefined
+        ? { rpc_error_code: exc.rpcErrorCode }
+        : {}),
     };
   }
 

--- a/typescript/src/errors.ts
+++ b/typescript/src/errors.ts
@@ -143,6 +143,15 @@ export class NegotiationError extends BNBAgentError {
  * which means the transaction failed (reverted, rejected, or never broadcast).
  */
 export class TransactionPendingError extends BNBAgentError {
+  /**
+   * Where in the relay-observability state machine this timeout sits:
+   * `"public_tx_pending"` (default — wait, do not re-send the nonce) or
+   * `"receipt_timeout_but_tx_visible"` (a relay hash the RPC has seen but
+   * that never mined within the timeout — likely stuck in the mempool;
+   * escalate rather than retry).
+   */
+  public relayStatus: RelayObservationStatus = "public_tx_pending";
+
   constructor(
     public readonly txHash: string,
     public readonly timeoutSeconds: number,
@@ -157,6 +166,24 @@ export class TransactionPendingError extends BNBAgentError {
 }
 
 /**
+ * Distinct outcomes of waiting on a relay/sponsored write. The previous
+ * single "timeout" collapsed states with opposite retry semantics; callers
+ * can now branch on `relayStatus` instead of parsing messages:
+ * - `public_tx_pending` — tx visible, still waiting: wait, never re-send.
+ * - `relay_submission_unverified` — relay returned a hash no RPC can see:
+ *   the SDK self-pay fallback handles it; blind resubmission is unsafe.
+ * - `relay_rejected` — the relay refused the submission; no nonce was
+ *   consumed, retrying (or self-paying) is safe.
+ * - `receipt_timeout_but_tx_visible` — tx seen but unmined for the whole
+ *   receipt timeout: likely gas-price-stuck, escalate.
+ */
+export type RelayObservationStatus =
+  | "public_tx_pending"
+  | "relay_submission_unverified"
+  | "relay_rejected"
+  | "receipt_timeout_but_tx_visible";
+
+/**
  * A relay returned a transaction hash, but the configured chain RPC never
  * observed that transaction before the receipt timeout expired.
  *
@@ -165,6 +192,20 @@ export class TransactionPendingError extends BNBAgentError {
  * known-pending transaction.
  */
 export class RelaySubmissionUnverifiedError extends BNBAgentError {
+  public readonly relayStatus: RelayObservationStatus =
+    "relay_submission_unverified";
+
+  /**
+   * Verdict of the multi-RPC secondary confirmation that ran before this
+   * error was acted on: `"confirmed-unseen"` (fallback RPCs corroborate),
+   * `"inconclusive"` (no fallback endpoint answered), or `"not-checked"`.
+   * Assigned by the executor after the error is raised by the receipt wait.
+   */
+  public secondaryRpcResult:
+    | "confirmed-unseen"
+    | "inconclusive"
+    | "not-checked" = "not-checked";
+
   constructor(
     public readonly txHash: string,
     public readonly timeoutSeconds: number,
@@ -205,6 +246,40 @@ export class RelayFallbackFailedError extends RelaySubmissionUnverifiedError {
       this.cause = options.cause;
     }
   }
+}
+
+/**
+ * The relay refused a sponsored submission outright.
+ *
+ * Deliberately NOT a subclass of {@link RelaySubmissionUnverifiedError} —
+ * the semantics are opposite: a definite rejection means no transaction was
+ * accepted and no nonce was consumed, so retrying (or self-paying the same
+ * payload) is safe. `definite` is `true` only for an explicit JSON-RPC error
+ * from the relay; an HTTP/transport failure sets `definite: false` because
+ * the submission may or may not have entered the relay queue, and callers
+ * must NOT automatically re-send in that ambiguous state.
+ */
+export class RelayRejectedError extends BNBAgentError {
+  public readonly relayStatus: RelayObservationStatus = "relay_rejected";
+
+  constructor(
+    public readonly reason: string,
+    public readonly definite: boolean,
+    options?: { rpcErrorCode?: number; cause?: unknown },
+  ) {
+    super(
+      definite
+        ? `Relay rejected the sponsored transaction: ${reason}. No nonce was consumed; the transaction can be safely retried or self-paid.`
+        : `Relay submission failed before acknowledgment: ${reason}. It is unknown whether the relay accepted the transaction — do not blindly resubmit; verify wallet nonce state first.`,
+    );
+    this.name = "RelayRejectedError";
+    this.rpcErrorCode = options?.rpcErrorCode;
+    if (options?.cause !== undefined) {
+      this.cause = options.cause;
+    }
+  }
+
+  public readonly rpcErrorCode?: number;
 }
 
 /**

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -47,8 +47,22 @@ export {
   TransactionPendingError,
   RelaySubmissionUnverifiedError,
   RelayFallbackFailedError,
+  RelayRejectedError,
   ERC8004PartialRegistrationError,
 } from "./errors.js";
+export type { RelayObservationStatus } from "./errors.js";
+
+// Relay observability — secondary confirmation of unseen relay hashes
+export {
+  confirmTxUnseen,
+  resolveFallbackRpcUrls,
+} from "./core/relayVerifier.js";
+export type {
+  RelayVerifierOpts,
+  SecondaryConfirmation,
+  TxPresenceProbe,
+  TxProbeResult,
+} from "./core/relayVerifier.js";
 
 // ERC-8004 Identity Registry
 export { ERC8004Agent } from "./erc8004/agent.js";
@@ -85,6 +99,8 @@ export {
   minGasPriceWei,
   setDefaultReceiptTimeout,
   getDefaultReceiptTimeout,
+  setRelayUnseenTimeout,
+  getRelayUnseenTimeout,
 } from "./core/txConfig.js";
 
 // Paymaster + nonce management

--- a/typescript/src/wallets/intents.ts
+++ b/typescript/src/wallets/intents.ts
@@ -99,6 +99,12 @@ export interface ExecutionContext {
    * SDK default. Self-broadcasting wallets ignore it.
    */
   relayUnseenTimeout?: number | null;
+  /**
+   * Extra RPC endpoints used to double-check an unseen relay hash before the
+   * self-pay fallback fires. Absent uses `BNBAGENT_FALLBACK_RPC_URLS`, then a
+   * built-in per-chain table. Self-broadcasting wallets ignore it.
+   */
+  fallbackRpcUrls?: string[] | null;
 }
 
 /**

--- a/typescript/src/wallets/localExecutor.ts
+++ b/typescript/src/wallets/localExecutor.ts
@@ -29,6 +29,11 @@ import {
   type NonceManagerClient,
 } from "../core/nonceManager.js";
 import type { Paymaster } from "../core/paymaster.js";
+import {
+  type RelayVerifierOpts,
+  type SecondaryConfirmation,
+  confirmTxUnseen,
+} from "../core/relayVerifier.js";
 import { getDefaultReceiptTimeout, minGasPriceWei } from "../core/txConfig.js";
 import {
   describeError,
@@ -42,6 +47,7 @@ import {
 } from "../core/txSender.js";
 import {
   RelayFallbackFailedError,
+  RelayRejectedError,
   RelaySubmissionUnverifiedError,
   TransactionPendingError,
 } from "../errors.js";
@@ -74,6 +80,17 @@ export interface LocalExecutorOpts {
    * (also the seam tests use to pin the raw unverified surface).
    */
   selfPayFallback?: boolean;
+  /**
+   * Extra RPC endpoints used to double-check that a relay-returned hash is
+   * really invisible before the self-pay fallback fires. `null`/absent falls
+   * back to `BNBAGENT_FALLBACK_RPC_URLS`, then a built-in per-chain table.
+   */
+  fallbackRpcUrls?: string[] | null;
+  /** Secondary-confirmation seam; tests replace the real multi-RPC probe. */
+  confirmTxUnseen?: (
+    hash: `0x${string}`,
+    opts: RelayVerifierOpts,
+  ) => Promise<SecondaryConfirmation>;
 }
 
 const USER_AGENT_HEADERS = { UserAgent: "bnbagent/v1.0.0" } as const;
@@ -96,6 +113,11 @@ export class LocalExecutor implements IntentExecutor {
   private readonly receiptTimeout: number | null;
   private readonly relayUnseenTimeout: number | null;
   private readonly selfPayFallback: boolean;
+  private readonly fallbackRpcUrls: string[] | null;
+  private readonly confirmTxUnseen: (
+    hash: `0x${string}`,
+    opts: RelayVerifierOpts,
+  ) => Promise<SecondaryConfirmation>;
 
   constructor(opts: LocalExecutorOpts) {
     this.client = opts.client;
@@ -104,6 +126,8 @@ export class LocalExecutor implements IntentExecutor {
     this.receiptTimeout = opts.receiptTimeout ?? null;
     this.relayUnseenTimeout = opts.relayUnseenTimeout ?? null;
     this.selfPayFallback = opts.selfPayFallback ?? true;
+    this.fallbackRpcUrls = opts.fallbackRpcUrls ?? null;
+    this.confirmTxUnseen = opts.confirmTxUnseen ?? confirmTxUnseen;
   }
 
   /** Execute an intent's mechanical `call`. */
@@ -134,15 +158,34 @@ export class LocalExecutor implements IntentExecutor {
       ));
 
     if (this.paymaster) {
-      const sponsored = await this.trySponsored({
-        paymaster: this.paymaster,
-        account,
-        to,
-        data,
-        value,
-        gas,
-        description,
-      });
+      let sponsored: {
+        hash: `0x${string}`;
+        tx: TransactionRequestLegacy & { chainId: number };
+      } | null;
+      try {
+        sponsored = await this.trySponsored({
+          paymaster: this.paymaster,
+          account,
+          to,
+          data,
+          value,
+          gas,
+          description,
+        });
+      } catch (error) {
+        if (error instanceof RelayRejectedError && error.definite) {
+          // The relay explicitly refused the submission — no nonce was
+          // consumed, so switching to a direct self-paid broadcast carries
+          // no double-broadcast risk. An ambiguous (definite=false) failure
+          // propagates instead: the tx may already sit in the relay queue.
+          console.warn(
+            `[LocalExecutor] relay rejected ${description} (${error.reason}); self-paying`,
+          );
+          sponsored = null;
+        } else {
+          throw error;
+        }
+      }
       if (sponsored) {
         const timeoutSeconds =
           this.receiptTimeout ?? getDefaultReceiptTimeout();
@@ -161,6 +204,30 @@ export class LocalExecutor implements IntentExecutor {
             error instanceof RelaySubmissionUnverifiedError &&
             this.selfPayFallback
           ) {
+            // Before charging the wallet, double-check against independent
+            // RPC endpoints that the relay hash is really invisible — a
+            // flaky primary RPC must not race a same-nonce self-pay against
+            // a transaction that actually reached the mempool.
+            const verdict = await this.secondaryConfirmation(
+              sponsored.hash,
+              sponsored.tx.chainId,
+            );
+            if (verdict === "seen") {
+              console.warn(
+                `[LocalExecutor] primary RPC never saw relay tx ${sponsored.hash}, but a fallback RPC can see it; waiting out the receipt instead of self-paying.`,
+              );
+              return await waitForReceiptAndInterpret(
+                this.client,
+                sponsored.hash,
+                timeoutSeconds,
+              );
+            }
+            error.secondaryRpcResult = verdict;
+            if (verdict === "inconclusive") {
+              console.warn(
+                `[LocalExecutor] no fallback RPC endpoint could corroborate that relay tx ${sponsored.hash} is unseen; proceeding with the self-pay fallback anyway.`,
+              );
+            }
             return await this.selfPayAfterUnverifiedRelay(
               sponsored,
               error,
@@ -427,6 +494,30 @@ export class LocalExecutor implements IntentExecutor {
         }
       }
       throw error;
+    }
+  }
+
+  /**
+   * Run the multi-RPC secondary confirmation for an unverified relay hash.
+   * Never throws — a verifier failure degrades to `"inconclusive"` so the
+   * self-pay safety net cannot be disabled by third-party RPC downtime.
+   */
+  private async secondaryConfirmation(
+    hash: `0x${string}`,
+    chainId: number,
+  ): Promise<SecondaryConfirmation> {
+    const transport = this.client.transport as unknown as
+      | { url?: string }
+      | undefined;
+    try {
+      return await this.confirmTxUnseen(hash, {
+        chainId,
+        primaryRpcUrl:
+          typeof transport?.url === "string" ? transport.url : undefined,
+        fallbackRpcUrls: this.fallbackRpcUrls,
+      });
+    } catch {
+      return "inconclusive";
     }
   }
 

--- a/typescript/src/wallets/twak/provider.ts
+++ b/typescript/src/wallets/twak/provider.ts
@@ -40,6 +40,11 @@ import { join } from "node:path";
 import { hashMessage, recoverMessageAddress } from "viem";
 import { NETWORKS, type NetworkConfig } from "../../config.js";
 import {
+  type RelayVerifierOpts,
+  type SecondaryConfirmation,
+  confirmTxUnseen,
+} from "../../core/relayVerifier.js";
+import {
   RelaySubmissionUnverifiedError,
   TransactionPendingError,
 } from "../../errors.js";
@@ -330,6 +335,14 @@ export interface TWAKProviderOptions {
    */
   expectedAddress?: string;
   /**
+   * Secondary-confirmation seam for sponsored receipt timeouts; tests
+   * replace the real multi-RPC probe. Default: {@link confirmTxUnseen}.
+   */
+  confirmTxUnseen?: (
+    hash: `0x${string}`,
+    opts: RelayVerifierOpts,
+  ) => Promise<SecondaryConfirmation>;
+  /**
    * `true` (default, dev-machine parity with `EVMWalletProvider`): a
    * missing wallet is created lazily on the first operation. Deployments
    * must pass `false`: the wallet may only come from materialization
@@ -375,6 +388,10 @@ export class TWAKProvider extends WalletProvider implements IntentExecutor {
   readonly #home: string | undefined;
   readonly #expectedAddress: string | undefined;
   readonly #autoCreate: boolean;
+  readonly #confirmTxUnseen: (
+    hash: `0x${string}`,
+    opts: RelayVerifierOpts,
+  ) => Promise<SecondaryConfirmation>;
   #address: `0x${string}` | null = null;
   #ensured = false; // guards the one-shot lazy auto-create
   /**
@@ -399,6 +416,7 @@ export class TWAKProvider extends WalletProvider implements IntentExecutor {
     this.#home = opts.home;
     this.#expectedAddress = opts.expectedAddress;
     this.#autoCreate = opts.autoCreate ?? true;
+    this.#confirmTxUnseen = opts.confirmTxUnseen ?? confirmTxUnseen;
   }
 
   /** The twak chain key this provider is pinned to. */
@@ -483,18 +501,44 @@ export class TWAKProvider extends WalletProvider implements IntentExecutor {
     } catch {
       publicTxVisible = false;
     }
+    let secondary: SecondaryConfirmation | "not-checked" = "not-checked";
+    if (!publicTxVisible) {
+      // Corroborate with independent RPC endpoints before declaring the
+      // relay hash unverified — the primary RPC alone may be lagging.
+      const networkName =
+        NETWORK_FOR_TWAK_CHAIN[
+          this.#chain as keyof typeof NETWORK_FOR_TWAK_CHAIN
+        ];
+      const chainId = NETWORKS[networkName]?.chainId;
+      try {
+        secondary = await this.#confirmTxUnseen(timeout.txHash, {
+          chainId: chainId ?? 0,
+        });
+      } catch {
+        secondary = "inconclusive";
+      }
+      if (secondary === "seen") {
+        publicTxVisible = true;
+      }
+    }
     if (publicTxVisible) {
-      return new TransactionPendingError(
+      const pending = new TransactionPendingError(
         timeout.txHash,
         TWAK_RECEIPT_TIMEOUT_SECONDS,
         `TWAK sponsored transaction ${timeout.txHash} is visible on the public chain, but TWAK timed out waiting for its receipt. Do not retry until the transaction or job state is reconciled.`,
       );
+      pending.relayStatus = "receipt_timeout_but_tx_visible";
+      return pending;
     }
-    return new RelaySubmissionUnverifiedError(
+    const unverified = new RelaySubmissionUnverifiedError(
       timeout.txHash,
       TWAK_RECEIPT_TIMEOUT_SECONDS,
       `TWAK sponsored relay returned transaction ${timeout.txHash}, but the SDK could not verify it on the public chain after TWAK timed out waiting for its receipt. Do not retry blindly; reconcile the relay transaction and wallet nonce before issuing another write.`,
     );
+    if (secondary === "confirmed-unseen" || secondary === "inconclusive") {
+      unverified.secondaryRpcResult = secondary;
+    }
+    return unverified;
   }
 
   /** Sync variant for the base-class `address` getter / `exists()` only. */

--- a/typescript/src/wallets/walletProvider.ts
+++ b/typescript/src/wallets/walletProvider.ts
@@ -226,6 +226,7 @@ export abstract class WalletProvider {
       paymaster: context.paymaster ?? null,
       receiptTimeout: context.receiptTimeout ?? null,
       relayUnseenTimeout: context.relayUnseenTimeout ?? null,
+      fallbackRpcUrls: context.fallbackRpcUrls ?? null,
     });
   }
 

--- a/typescript/tests/erc8183JobOps.test.ts
+++ b/typescript/tests/erc8183JobOps.test.ts
@@ -39,6 +39,7 @@ import {
 } from "../src/erc8183/negotiation.js";
 import { type Job, JobStatus } from "../src/erc8183/types.js";
 import {
+  RelayRejectedError,
   RelaySubmissionUnverifiedError,
   RpcRangeLimitError,
   TransactionPendingError,
@@ -1462,5 +1463,23 @@ describe("ERC8183JobOps: retryable contract", () => {
     expect(fields.error_code).toBe("tx_unverified");
     expect(fields.retryable).toBe(false);
     expect(fields.tx_hash).toBe(`0x${"cd".repeat(32)}`);
+  });
+
+  it("a definite relay rejection is retryable and carries the rpc code", () => {
+    const exc = new RelayRejectedError("not sponsorable", true, {
+      rpcErrorCode: -32000,
+    });
+    const fields = excErrorFields(exc);
+    expect(fields.error_code).toBe("relay_rejected");
+    expect(fields.retryable).toBe(true);
+    expect(fields.rpc_error_code).toBe(-32000);
+  });
+
+  it("an ambiguous relay failure is not retryable", () => {
+    const exc = new RelayRejectedError("HTTP error 502", false);
+    const fields = excErrorFields(exc);
+    expect(fields.error_code).toBe("relay_rejected");
+    expect(fields.retryable).toBe(false);
+    expect(fields).not.toHaveProperty("rpc_error_code");
   });
 });

--- a/typescript/tests/errors.test.ts
+++ b/typescript/tests/errors.test.ts
@@ -9,6 +9,7 @@ import {
   NegotiationError,
   NetworkError,
   RelayFallbackFailedError,
+  RelayRejectedError,
   RelaySubmissionUnverifiedError,
   RpcRangeLimitError,
   StorageError,
@@ -179,12 +180,60 @@ describe("RelaySubmissionUnverifiedError", () => {
   });
 });
 
+describe("relay observation status fields", () => {
+  it("TransactionPendingError defaults to public_tx_pending", () => {
+    const error = new TransactionPendingError("0xabc", 300);
+    expect(error.relayStatus).toBe("public_tx_pending");
+  });
+
+  it("TransactionPendingError can carry receipt_timeout_but_tx_visible", () => {
+    const error = new TransactionPendingError("0xabc", 300);
+    error.relayStatus = "receipt_timeout_but_tx_visible";
+    expect(error.relayStatus).toBe("receipt_timeout_but_tx_visible");
+  });
+
+  it("RelaySubmissionUnverifiedError pins relay_submission_unverified and defaults not-checked", () => {
+    const error = new RelaySubmissionUnverifiedError("0xabc", 30);
+    expect(error.relayStatus).toBe("relay_submission_unverified");
+    expect(error.secondaryRpcResult).toBe("not-checked");
+  });
+});
+
+describe("RelayRejectedError", () => {
+  it("is NOT a RelaySubmissionUnverifiedError (opposite retry semantics)", () => {
+    const error = new RelayRejectedError("not sponsorable", true);
+    expect(error).toBeInstanceOf(BNBAgentError);
+    expect(error).not.toBeInstanceOf(RelaySubmissionUnverifiedError);
+    expect(error.name).toBe("RelayRejectedError");
+    expect(error.relayStatus).toBe("relay_rejected");
+  });
+
+  it("a definite rejection says retrying is safe", () => {
+    const error = new RelayRejectedError("bad tx", true, {
+      rpcErrorCode: -32600,
+    });
+    expect(error.definite).toBe(true);
+    expect(error.rpcErrorCode).toBe(-32600);
+    expect(error.message).toContain("safely retried");
+  });
+
+  it("an ambiguous failure forbids blind resubmission and keeps the cause", () => {
+    const cause = new Error("ECONNRESET");
+    const error = new RelayRejectedError("socket hang up", false, { cause });
+    expect(error.definite).toBe(false);
+    expect(error.message).toContain("do not blindly resubmit");
+    expect(error.cause).toBe(cause);
+  });
+});
+
 describe("RelayFallbackFailedError", () => {
   it("extends RelaySubmissionUnverifiedError so classification is inherited", () => {
     const error = new RelayFallbackFailedError("0xabc", 30, "no gas");
     expect(error).toBeInstanceOf(RelaySubmissionUnverifiedError);
     expect(error).toBeInstanceOf(BNBAgentError);
     expect(error.name).toBe("RelayFallbackFailedError");
+    // The relayStatus discriminator is inherited unchanged.
+    expect(error.relayStatus).toBe("relay_submission_unverified");
   });
 
   it("surfaces the fallback reason and funding guidance", () => {

--- a/typescript/tests/localExecutorPaymaster.test.ts
+++ b/typescript/tests/localExecutorPaymaster.test.ts
@@ -11,7 +11,7 @@ import {
   _resetTxConfigOverrides,
   setDefaultReceiptTimeout,
 } from "../src/core/txConfig.js";
-import { TransactionPendingError } from "../src/errors.js";
+import { RelayRejectedError, TransactionPendingError } from "../src/errors.js";
 import {
   RelayFallbackFailedError,
   RelaySubmissionUnverifiedError,
@@ -23,6 +23,7 @@ import {
   WalletProvider,
 } from "../src/wallets/walletProvider.js";
 import {
+  FAKE_CHAIN_ID,
   FAKE_TX_HASH,
   type MockHandlers,
   mockPublicClient,
@@ -989,5 +990,216 @@ describe("LocalExecutor: self-pay fallback after unverified relay", () => {
 
     expect(error).toBeInstanceOf(RelaySubmissionUnverifiedError);
     expect(sendRawCount(mock)).toBe(0); // no self-pay broadcast
+  });
+});
+
+describe("LocalExecutor: multi-RPC secondary confirmation", () => {
+  function receiptFor(hash: `0x${string}`) {
+    return {
+      status: "0x1",
+      blockNumber: "0x1",
+      blockHash: `0x${"aa".repeat(32)}`,
+      transactionHash: hash,
+      transactionIndex: "0x0",
+      from: WALLET_ADDRESS,
+      to: CONTRACT_ADDRESS,
+      cumulativeGasUsed: "0x1e8480",
+      gasUsed: "0x186a0",
+      contractAddress: null,
+      logs: [],
+      logsBloom: `0x${"0".repeat(512)}`,
+      effectiveGasPrice: "0x3b9aca00",
+    };
+  }
+
+  it("a fallback RPC that can see the tx suppresses the self-pay and waits out the receipt", async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let receiptAvailable = false;
+    const mock = mockPublicClient({
+      eth_getTransactionReceipt: () => {
+        if (receiptAvailable) return receiptFor(PAYMASTER_TX_HASH);
+        throw new Error("not found");
+      },
+    });
+    const wallet = new StubWallet();
+    const { paymaster } = makeFakePaymaster();
+    const confirmSeam = vi.fn(
+      async (_hash: `0x${string}`, _opts: { chainId: number }) => {
+        receiptAvailable = true;
+        return "seen" as const;
+      },
+    );
+    const executor = new LocalExecutor({
+      client: mock.client,
+      walletProvider: wallet,
+      paymaster,
+      receiptTimeout: 5,
+      relayUnseenTimeout: 1,
+      confirmTxUnseen: confirmSeam,
+    });
+
+    const promise = executor.execute(makeIntent());
+    await vi.advanceTimersByTimeAsync(5_000);
+    const result = await promise;
+
+    expect(result.status).toBe(1);
+    expect(result.transactionHash).toBe(PAYMASTER_TX_HASH);
+    expect(confirmSeam).toHaveBeenCalledOnce();
+    expect(confirmSeam.mock.calls[0]?.[0]).toBe(PAYMASTER_TX_HASH);
+    expect(confirmSeam.mock.calls[0]?.[1]).toMatchObject({
+      chainId: FAKE_CHAIN_ID,
+    });
+    // No self-pay: only the sponsored sign, no direct broadcast.
+    expect(sendRawCount(mock)).toBe(0);
+    expect(wallet.signedTxs).toHaveLength(1);
+    expect(
+      warnSpy.mock.calls.some((args) =>
+        String(args[0]).includes("fallback RPC can see it"),
+      ),
+    ).toBe(true);
+  });
+
+  it("confirmed-unseen proceeds with the self-pay fallback", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mock = mockPublicClient({
+      eth_getTransactionReceipt: (params) => {
+        if (params[0] === FAKE_TX_HASH) return receiptFor(FAKE_TX_HASH);
+        throw new Error("not found");
+      },
+    });
+    const wallet = new StubWallet();
+    const { paymaster } = makeFakePaymaster();
+    const confirmSeam = vi.fn(async () => "confirmed-unseen" as const);
+    const executor = new LocalExecutor({
+      client: mock.client,
+      walletProvider: wallet,
+      paymaster,
+      receiptTimeout: 1,
+      confirmTxUnseen: confirmSeam,
+    });
+
+    const promise = executor.execute(makeIntent());
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await promise;
+
+    expect(result.transactionHash).toBe(FAKE_TX_HASH);
+    expect(confirmSeam).toHaveBeenCalledOnce();
+    expect(sendRawCount(mock)).toBe(1); // exactly one self-pay broadcast
+  });
+
+  it("inconclusive keeps the pre-existing self-pay behavior and warns", async () => {
+    vi.useFakeTimers();
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mock = mockPublicClient({
+      eth_getTransactionReceipt: (params) => {
+        if (params[0] === FAKE_TX_HASH) return receiptFor(FAKE_TX_HASH);
+        throw new Error("not found");
+      },
+    });
+    const { paymaster } = makeFakePaymaster();
+    const executor = new LocalExecutor({
+      client: mock.client,
+      walletProvider: new StubWallet(),
+      paymaster,
+      receiptTimeout: 1,
+      confirmTxUnseen: async () => "inconclusive",
+    });
+
+    const promise = executor.execute(makeIntent());
+    await vi.advanceTimersByTimeAsync(1_000);
+    const result = await promise;
+
+    expect(result.transactionHash).toBe(FAKE_TX_HASH);
+    expect(sendRawCount(mock)).toBe(1);
+    expect(
+      warnSpy.mock.calls.some((args) =>
+        String(args[0]).includes("could corroborate"),
+      ),
+    ).toBe(true);
+  });
+
+  it("fallbackRpcUrls from the constructor reach the verifier opts", async () => {
+    vi.useFakeTimers();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mock = mockPublicClient({
+      eth_getTransactionReceipt: (params) => {
+        if (params[0] === FAKE_TX_HASH) return receiptFor(FAKE_TX_HASH);
+        throw new Error("not found");
+      },
+    });
+    const { paymaster } = makeFakePaymaster();
+    const confirmSeam = vi.fn(
+      async (
+        _hash: `0x${string}`,
+        _opts: { fallbackRpcUrls?: string[] | null },
+      ) => "confirmed-unseen" as const,
+    );
+    const executor = new LocalExecutor({
+      client: mock.client,
+      walletProvider: new StubWallet(),
+      paymaster,
+      receiptTimeout: 1,
+      fallbackRpcUrls: ["https://alt.example"],
+      confirmTxUnseen: confirmSeam,
+    });
+
+    const promise = executor.execute(makeIntent());
+    await vi.advanceTimersByTimeAsync(1_000);
+    await promise;
+
+    expect(confirmSeam.mock.calls[0]?.[1]).toMatchObject({
+      fallbackRpcUrls: ["https://alt.example"],
+    });
+  });
+});
+
+describe("LocalExecutor: relay rejection classification", () => {
+  it("a definite relay rejection falls straight back to self-pay", async () => {
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const mock = mockPublicClient();
+    const wallet = new StubWallet();
+    const { paymaster } = makeFakePaymaster({
+      ethSendRawTransaction: async () => {
+        throw new RelayRejectedError(
+          "RPC error [-32000]: not sponsorable",
+          true,
+          {
+            rpcErrorCode: -32000,
+          },
+        );
+      },
+    });
+    const executor = new LocalExecutor({
+      client: mock.client,
+      walletProvider: wallet,
+      paymaster,
+    });
+
+    const result = await executor.execute(makeIntent());
+
+    expect(result.status).toBe(1);
+    // The self-pay path broadcast directly through the client.
+    expect(sendRawCount(mock)).toBe(1);
+  });
+
+  it("an ambiguous (definite=false) relay failure propagates and never self-pays", async () => {
+    const mock = mockPublicClient();
+    const { paymaster } = makeFakePaymaster({
+      ethSendRawTransaction: async () => {
+        throw new RelayRejectedError("HTTP error 502", false);
+      },
+    });
+    const executor = new LocalExecutor({
+      client: mock.client,
+      walletProvider: new StubWallet(),
+      paymaster,
+    });
+
+    await expect(executor.execute(makeIntent())).rejects.toBeInstanceOf(
+      RelayRejectedError,
+    );
+    expect(sendRawCount(mock)).toBe(0);
   });
 });

--- a/typescript/tests/paymaster.test.ts
+++ b/typescript/tests/paymaster.test.ts
@@ -1,6 +1,7 @@
 import { getAddress } from "viem";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Paymaster, toAddressHex, toHex } from "../src/core/paymaster.js";
+import { RelayRejectedError } from "../src/errors.js";
 
 const PAYMASTER_URL = "https://paymaster.example.com";
 const ADDRESS = "0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18";
@@ -295,5 +296,71 @@ describe("Paymaster", () => {
 
     const [, init] = mock.mock.calls[0];
     expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+});
+
+describe("Paymaster: ethSendRawTransaction relay-rejection classification", () => {
+  beforeEach(() => {
+    vi.stubGlobal("fetch", fetchMock());
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it("a JSON-RPC error is a definite RelayRejectedError with the rpc code", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({ error: { message: "not sponsorable", code: -32000 } }),
+    );
+
+    const pm = new Paymaster(PAYMASTER_URL);
+    const error = await pm.ethSendRawTransaction("0xsignedtx").catch((e) => e);
+
+    expect(error).toBeInstanceOf(RelayRejectedError);
+    expect(error).toMatchObject({
+      name: "RelayRejectedError",
+      definite: true,
+      rpcErrorCode: -32000,
+      relayStatus: "relay_rejected",
+    });
+    expect(error.message).toContain("safely retried");
+  });
+
+  it("a non-2xx HTTP response is an ambiguous (definite=false) rejection", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({}, 502),
+    );
+
+    const pm = new Paymaster(PAYMASTER_URL);
+    const error = await pm.ethSendRawTransaction("0xsignedtx").catch((e) => e);
+
+    expect(error).toBeInstanceOf(RelayRejectedError);
+    expect(error.definite).toBe(false);
+    expect(error.message).toContain("do not blindly resubmit");
+  });
+
+  it("a transport failure is an ambiguous rejection carrying the cause", async () => {
+    const networkError = new Error("refused");
+    (fetch as ReturnType<typeof vi.fn>).mockRejectedValue(networkError);
+
+    const pm = new Paymaster(PAYMASTER_URL);
+    const error = await pm.ethSendRawTransaction("0xsignedtx").catch((e) => e);
+
+    expect(error).toBeInstanceOf(RelayRejectedError);
+    expect(error.definite).toBe(false);
+    expect(error.cause).toBe(networkError);
+  });
+
+  it("read methods keep their plain-Error shape (no RelayRejectedError)", async () => {
+    (fetch as ReturnType<typeof vi.fn>).mockResolvedValue(
+      mockResponse({ error: { message: "bad request", code: -32600 } }),
+    );
+
+    const pm = new Paymaster(PAYMASTER_URL);
+    const error = await pm.ethGetTransactionCount(ADDRESS).catch((e) => e);
+    expect(error).not.toBeInstanceOf(RelayRejectedError);
+    expect(error.message).toBe("RPC error [-32600]: bad request");
   });
 });

--- a/typescript/tests/relayVerifier.test.ts
+++ b/typescript/tests/relayVerifier.test.ts
@@ -1,0 +1,151 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  RELAY_VERIFIER_ENDPOINT_TIMEOUT_MS,
+  type TxProbeResult,
+  confirmTxUnseen,
+  resolveFallbackRpcUrls,
+} from "../src/core/relayVerifier.js";
+import {
+  BSC_MAINNET_CHAIN_ID,
+  BSC_TESTNET_CHAIN_ID,
+} from "../src/networks/addresses.js";
+
+const HASH = `0x${"ab".repeat(32)}` as `0x${string}`;
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+/** Build a probe that answers per-URL from a lookup table. */
+function tableProbe(
+  table: Record<string, TxProbeResult>,
+): (url: string) => Promise<TxProbeResult> {
+  return async (url: string) => table[url] ?? "error";
+}
+
+describe("resolveFallbackRpcUrls", () => {
+  it("explicit opts beat env and the built-in table", () => {
+    vi.stubEnv("BNBAGENT_FALLBACK_RPC_URLS", "https://env.example");
+    expect(
+      resolveFallbackRpcUrls({
+        chainId: BSC_TESTNET_CHAIN_ID,
+        fallbackRpcUrls: ["https://a.example", "https://b.example"],
+      }),
+    ).toEqual(["https://a.example", "https://b.example"]);
+  });
+
+  it("env (comma-separated) beats the built-in table", () => {
+    vi.stubEnv(
+      "BNBAGENT_FALLBACK_RPC_URLS",
+      " https://x.example , https://y.example ,",
+    );
+    expect(resolveFallbackRpcUrls({ chainId: BSC_TESTNET_CHAIN_ID })).toEqual([
+      "https://x.example",
+      "https://y.example",
+    ]);
+  });
+
+  it("falls back to the built-in per-chain table", () => {
+    const testnet = resolveFallbackRpcUrls({ chainId: BSC_TESTNET_CHAIN_ID });
+    const mainnet = resolveFallbackRpcUrls({ chainId: BSC_MAINNET_CHAIN_ID });
+    expect(testnet.length).toBeGreaterThan(0);
+    expect(mainnet.length).toBeGreaterThan(0);
+    expect(testnet.every((u) => u.startsWith("https://"))).toBe(true);
+  });
+
+  it("unknown chain yields no endpoints", () => {
+    expect(resolveFallbackRpcUrls({ chainId: 1337 })).toEqual([]);
+  });
+
+  it("dedupes the primary RPC (case/trailing-slash-insensitive) and repeats", () => {
+    expect(
+      resolveFallbackRpcUrls({
+        chainId: BSC_TESTNET_CHAIN_ID,
+        primaryRpcUrl: "https://A.example/",
+        fallbackRpcUrls: [
+          "https://a.example",
+          "https://b.example",
+          "https://b.example/",
+        ],
+      }),
+    ).toEqual(["https://b.example"]);
+  });
+});
+
+describe("confirmTxUnseen", () => {
+  it("all unseen -> confirmed-unseen", async () => {
+    const verdict = await confirmTxUnseen(HASH, {
+      chainId: BSC_TESTNET_CHAIN_ID,
+      fallbackRpcUrls: ["u1", "u2"],
+      probe: tableProbe({ u1: "unseen", u2: "unseen" }),
+    });
+    expect(verdict).toBe("confirmed-unseen");
+  });
+
+  it("a single seen endpoint wins -> seen", async () => {
+    const verdict = await confirmTxUnseen(HASH, {
+      chainId: BSC_TESTNET_CHAIN_ID,
+      fallbackRpcUrls: ["u1", "u2", "u3"],
+      probe: tableProbe({ u1: "unseen", u2: "seen", u3: "error" }),
+    });
+    expect(verdict).toBe("seen");
+  });
+
+  it("mixed error + unseen -> confirmed-unseen (one authoritative answer suffices)", async () => {
+    const verdict = await confirmTxUnseen(HASH, {
+      chainId: BSC_TESTNET_CHAIN_ID,
+      fallbackRpcUrls: ["u1", "u2"],
+      probe: tableProbe({ u1: "error", u2: "unseen" }),
+    });
+    expect(verdict).toBe("confirmed-unseen");
+  });
+
+  it("all error -> inconclusive", async () => {
+    const verdict = await confirmTxUnseen(HASH, {
+      chainId: BSC_TESTNET_CHAIN_ID,
+      fallbackRpcUrls: ["u1", "u2"],
+      probe: tableProbe({}),
+    });
+    expect(verdict).toBe("inconclusive");
+  });
+
+  it("a throwing probe counts as error, never rejects", async () => {
+    const verdict = await confirmTxUnseen(HASH, {
+      chainId: BSC_TESTNET_CHAIN_ID,
+      fallbackRpcUrls: ["u1"],
+      probe: async () => {
+        throw new Error("boom");
+      },
+    });
+    expect(verdict).toBe("inconclusive");
+  });
+
+  it("no usable endpoints -> inconclusive without probing", async () => {
+    const probe = vi.fn(async (): Promise<TxProbeResult> => "unseen");
+    const verdict = await confirmTxUnseen(HASH, {
+      chainId: 1337,
+      probe,
+    });
+    expect(verdict).toBe("inconclusive");
+    expect(probe).not.toHaveBeenCalled();
+  });
+
+  it("passes the per-endpoint timeout to the probe", async () => {
+    const probe = vi.fn(
+      async (
+        _url: string,
+        _hash: `0x${string}`,
+        timeoutMs: number,
+      ): Promise<TxProbeResult> => {
+        expect(timeoutMs).toBe(RELAY_VERIFIER_ENDPOINT_TIMEOUT_MS);
+        return "unseen";
+      },
+    );
+    await confirmTxUnseen(HASH, {
+      chainId: BSC_TESTNET_CHAIN_ID,
+      fallbackRpcUrls: ["u1"],
+      probe,
+    });
+    expect(probe).toHaveBeenCalledOnce();
+  });
+});

--- a/typescript/tests/twakProvider.test.ts
+++ b/typescript/tests/twakProvider.test.ts
@@ -642,7 +642,14 @@ describe("TWAKProvider — sponsored receipt-timeout classification", () => {
   it("marks a relay hash unseen by the public RPC as unverified", async () => {
     installRouter((args) => (args[0] === "wallet" ? STATUS_OK : timeoutResult));
     const getTransaction = vi.fn().mockRejectedValue(new Error("not found"));
-    const twak = new TWAKProvider({ chain: "bsctestnet" });
+    const confirmSeam = vi.fn(
+      async (_hash: `0x${string}`, _opts: { chainId: number }) =>
+        "confirmed-unseen" as const,
+    );
+    const twak = new TWAKProvider({
+      chain: "bsctestnet",
+      confirmTxUnseen: confirmSeam,
+    });
     twak.makeExecutor(
       ctx(new Paymaster(PM_URL), {
         getTransaction,
@@ -660,9 +667,42 @@ describe("TWAKProvider — sponsored receipt-timeout classification", () => {
     }
 
     expect(caught).toBeInstanceOf(RelaySubmissionUnverifiedError);
-    expect(caught).toMatchObject({ txHash: hash });
+    expect(caught).toMatchObject({
+      txHash: hash,
+      secondaryRpcResult: "confirmed-unseen",
+    });
     expect(String(caught)).toContain("Do not retry blindly");
     expect(getTransaction).toHaveBeenCalledWith({ hash });
+    // The secondary confirmation ran against the bsctestnet chain id.
+    expect(confirmSeam).toHaveBeenCalledOnce();
+    expect(confirmSeam.mock.calls[0]?.[1]).toMatchObject({ chainId: 97 });
+  });
+
+  it("a fallback RPC that can see the hash reclassifies it as pending", async () => {
+    installRouter((args) => (args[0] === "wallet" ? STATUS_OK : timeoutResult));
+    const getTransaction = vi.fn().mockRejectedValue(new Error("not found"));
+    const twak = new TWAKProvider({
+      chain: "bsctestnet",
+      confirmTxUnseen: async () => "seen",
+    });
+    twak.makeExecutor(
+      ctx(new Paymaster(PM_URL), {
+        getTransaction,
+      } as unknown as ExecutionContext["client"]),
+    );
+
+    let caught: unknown;
+    try {
+      await twak.execute({ name: ERC8183_DISPUTE, kwargs: { jobId: 1n } });
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBeInstanceOf(TransactionPendingError);
+    expect(caught).toMatchObject({
+      txHash: hash,
+      relayStatus: "receipt_timeout_but_tx_visible",
+    });
   });
 
   it("marks a public-chain-visible hash as pending", async () => {

--- a/typescript/tests/txConfig.test.ts
+++ b/typescript/tests/txConfig.test.ts
@@ -1,12 +1,15 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   DEFAULT_RECEIPT_TIMEOUT,
+  DEFAULT_RELAY_UNSEEN_TIMEOUT,
   MIN_GAS_PRICE_WEI,
   _resetTxConfigOverrides,
   getDefaultReceiptTimeout,
+  getRelayUnseenTimeout,
   minGasPriceWei,
   setDefaultReceiptTimeout,
   setMinGasPriceWei,
+  setRelayUnseenTimeout,
 } from "../src/core/txConfig.js";
 import {
   BSC_MAINNET_CHAIN_ID,
@@ -112,12 +115,55 @@ describe("getDefaultReceiptTimeout", () => {
   });
 });
 
+describe("getRelayUnseenTimeout", () => {
+  it("defaults to 30", () => {
+    expect(getRelayUnseenTimeout()).toBe(DEFAULT_RELAY_UNSEEN_TIMEOUT);
+    expect(DEFAULT_RELAY_UNSEEN_TIMEOUT).toBe(30);
+  });
+
+  it("env overrides the default", () => {
+    vi.stubEnv("BNBAGENT_RELAY_UNSEEN_TIMEOUT", "90");
+    expect(getRelayUnseenTimeout()).toBe(90);
+  });
+
+  it("env value 0 disables the early abort", () => {
+    vi.stubEnv("BNBAGENT_RELAY_UNSEEN_TIMEOUT", "0");
+    expect(getRelayUnseenTimeout()).toBe(0);
+  });
+
+  it("invalid env is ignored", () => {
+    vi.stubEnv("BNBAGENT_RELAY_UNSEEN_TIMEOUT", "soon");
+    expect(getRelayUnseenTimeout()).toBe(30);
+  });
+
+  it("negative env is ignored", () => {
+    vi.stubEnv("BNBAGENT_RELAY_UNSEEN_TIMEOUT", "-5");
+    expect(getRelayUnseenTimeout()).toBe(30);
+  });
+
+  it("setter overrides env", () => {
+    vi.stubEnv("BNBAGENT_RELAY_UNSEEN_TIMEOUT", "90");
+    setRelayUnseenTimeout(45);
+    expect(getRelayUnseenTimeout()).toBe(45);
+  });
+
+  it("setter accepts 0 (disable) but rejects negatives", () => {
+    setRelayUnseenTimeout(0);
+    expect(getRelayUnseenTimeout()).toBe(0);
+    expect(() => setRelayUnseenTimeout(-1)).toThrow(
+      "relay unseen timeout must be >= 0",
+    );
+  });
+});
+
 describe("_resetTxConfigOverrides", () => {
-  it("clears both overrides back to env/default precedence", () => {
+  it("clears all overrides back to env/default precedence", () => {
     setMinGasPriceWei(9_000_000_000n);
     setDefaultReceiptTimeout(42);
+    setRelayUnseenTimeout(7);
     _resetTxConfigOverrides();
     expect(minGasPriceWei(BSC_TESTNET_CHAIN_ID)).toBe(ONE_GWEI);
     expect(getDefaultReceiptTimeout()).toBe(300);
+    expect(getRelayUnseenTimeout()).toBe(30);
   });
 });


### PR DESCRIPTION
## Summary

Full hardening of the MegaFuel relay observability surface, addressing the studio-side remainder of the alpha.5 QA review of BUG-029 (relay-accepted tx hash never observable on-chain).

### 1. Configurable relay-unseen timeout (was hardcoded 30s)
- `BNBAGENT_RELAY_UNSEEN_TIMEOUT` env var (seconds; `0` disables the early abort)
- `setRelayUnseenTimeout()` / `getRelayUnseenTimeout()` module API, resolved lazily at execute time (same pattern as the receipt timeout)
- `RELAY_UNSEEN_ABORT_SECONDS` kept as a deprecated alias

### 2. Multi-RPC secondary confirmation (new `core/relayVerifier.ts`)
Before the same-nonce self-pay fallback fires, `confirmTxUnseen` probes independent RPC endpoints (opts > `BNBAGENT_FALLBACK_RPC_URLS` > built-in 56/97 table, primary deduped):
- any endpoint **sees** the tx → the fallback is suppressed and the receipt wait continues (kills the flaky-primary-RPC same-nonce race)
- confirmed unseen / all endpoints down → existing self-pay behavior kept (the safety net never depends on third-party RPC availability)
- wired into both `LocalExecutor` and `TWAKProvider`'s sponsored receipt-timeout classification

### 3. Four-state relay observation machine
`relayStatus` discriminator on the tx-wait errors + a new `RelayRejectedError`:

| relayStatus | carrier | caller semantics |
|---|---|---|
| `public_tx_pending` | TransactionPendingError | wait, never re-send |
| `receipt_timeout_but_tx_visible` | TransactionPendingError | likely mempool-stuck, escalate |
| `relay_submission_unverified` | RelaySubmissionUnverifiedError (+`secondaryRpcResult`) | SDK self-pay fallback (only trigger state) |
| `relay_rejected` | **new** RelayRejectedError (`definite` flag) | definite → nonce unconsumed, auto self-pay; ambiguous → never auto-resend |

`jobOps.excErrorFields` maps it to `error_code: "relay_rejected"` (retryable only when definite).

**Backward compatible**: error names, constructor signatures, and the `RelayFallbackFailedError extends RelaySubmissionUnverifiedError` chain are unchanged (studio classifies by `error.name`).

## Testing
- `pnpm run check` (typecheck + biome + vitest + tsup build) green: **48 files, 1084 passed | 1 skipped**
- New/extended coverage: relayVerifier full matrix (fake probe, no network), localExecutor secondary-confirmation & rejection classification, paymaster send-path classification, errors compatibility (instanceof/name), twakProvider reclassification, jobOps mapping, txConfig precedence