### PR TITLE
docs: add live version badges for the Python and TypeScript SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # BNBAgent SDK
 
+[![PyPI](https://img.shields.io/pypi/v/bnbagent?logo=pypi&logoColor=white&label=bnbagent%20%28PyPI%29)](https://pypi.org/project/bnbagent/)
+[![npm](https://img.shields.io/npm/v/%40bnbagent%2Fsdk?logo=npm&label=%40bnbagent%2Fsdk%20%28npm%29)](https://www.npmjs.com/package/@bnbagent/sdk)
+[![Python](https://img.shields.io/pypi/pyversions/bnbagent)](https://pypi.org/project/bnbagent/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](./LICENSE)
+
 BNBAgent provides first-class Python and TypeScript SDKs for building on-chain AI agents on BNB Chain - register identities, negotiate, accept jobs, deliver work, and get paid trustlessly through on-chain escrow.
 
 Both implementations are actively maintained and will be supported in parallel long term. Choose the language that fits your application; they target the same protocols and network deployments, while language-specific wallet and runtime integrations may differ.
@@ -15,10 +20,14 @@ The SDK exposes two core capabilities:
 
 The Python and TypeScript SDKs live in the same repository and ship independently. Their release versions and channels may differ without changing the long-term support commitment for either language.
 
-| Directory | Language | Package | Support |
-| --- | --- | --- | --- |
-| [`python/`](./python) | Python | [`bnbagent`](https://pypi.org/project/bnbagent/) on PyPI | First-class, long-term |
-| [`typescript/`](./typescript) | TypeScript | [`@bnbagent/sdk`](https://www.npmjs.com/package/@bnbagent/sdk) on npm | First-class, long-term |
+| Directory | Language | Package | Current version | Support |
+| --- | --- | --- | --- | --- |
+| [`python/`](./python) | Python | [`bnbagent`](https://pypi.org/project/bnbagent/) on PyPI | [![PyPI](https://img.shields.io/pypi/v/bnbagent?label=%20)](https://pypi.org/project/bnbagent/) | First-class, long-term |
+| [`typescript/`](./typescript) | TypeScript | [`@bnbagent/sdk`](https://www.npmjs.com/package/@bnbagent/sdk) on npm | [![npm](https://img.shields.io/npm/v/%40bnbagent%2Fsdk?label=%20)](https://www.npmjs.com/package/@bnbagent/sdk) | First-class, long-term |
+
+The two badges above are live: because Python and TypeScript ship independently, they will
+often show different numbers. That is expected and does not indicate that either language is
+behind — see the release-channel note above.
 
 Shared, language-neutral material lives at the root:
 

--- a/python/README.md
+++ b/python/README.md
@@ -1,5 +1,9 @@
 # BNBAgent SDK
 
+[![PyPI](https://img.shields.io/pypi/v/bnbagent?logo=pypi&logoColor=white&label=bnbagent)](https://pypi.org/project/bnbagent/)
+[![Python](https://img.shields.io/pypi/pyversions/bnbagent)](https://pypi.org/project/bnbagent/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](../LICENSE)
+
 Python SDK for building on-chain AI agents on BNB Chain - register identities, negotiate, accept jobs, deliver work, and get paid trustlessly through on-chain escrow.
 
 BNBAgent SDK provides two core capabilities:

--- a/typescript/README.md
+++ b/typescript/README.md
@@ -1,5 +1,9 @@
 # @bnbagent/sdk
 
+[![npm](https://img.shields.io/npm/v/%40bnbagent%2Fsdk?logo=npm&label=%40bnbagent%2Fsdk)](https://www.npmjs.com/package/@bnbagent/sdk)
+[![Node](https://img.shields.io/node/v/%40bnbagent%2Fsdk)](https://www.npmjs.com/package/@bnbagent/sdk)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue)](../LICENSE)
+
 TypeScript toolkit for building on-chain AI agents on BNB Chain: ERC-8004 identity, the ERC-8183 agentic-commerce protocol (escrow + evaluation + optimistic dispute policy), x402 micropayments, wallets (local keystore + pluggable executors), and the supporting core (paymaster, nonce management, tx tuning).
 
 This is a layered port of the reference [Python SDK](../python) - same protocol semantics, same on-chain deployments, idiomatic TypeScript API. See [`ARCHITECTURE.md`](../ARCHITECTURE.md) for the full protocol reference; this README covers the TypeScript-specific surface and quickstart.


### PR DESCRIPTION
## Summary

The Python and TypeScript SDKs ship independently, so their published versions routinely differ — currently **`bnbagent` 0.4.3** on PyPI vs **`@bnbagent/sdk` 0.5.1** on npm.

The README already explains that *"release versions and channels may differ"*, but there is no way to see the current version of either package without leaving the page. Someone comparing the two numbers elsewhere can easily read the gap as one language being neglected, which contradicts the "first-class, long-term" commitment stated directly above the table.

## Changes

- **Root `README.md`** — PyPI / npm / supported-Python / license badges under the title, plus a **Current version** column in the SDKs table so both numbers sit side by side.
- **`python/README.md`**, **`typescript/README.md`** — matching per-language badges.
- A one-line note under the table stating plainly that differing numbers are expected and do not mean either language is behind.

Badges are live, so they stay correct on their own after each release — no manual bump needed.

## Verification

All four badge endpoints were checked against the live registries:

| Badge | Resolves to |
|---|---|
| `pypi/v/bnbagent` | `v0.4.3` |
| `npm/v/@bnbagent/sdk` | `v0.5.1` |
| `pypi/pyversions/bnbagent` | `3.10 \| 3.11 \| 3.12` |
| `node/v/@bnbagent/sdk` | `>=20` |

MIT license claim confirmed against `LICENSE`, `typescript/package.json`, and `python/pyproject.toml`.

Docs-only change — no code, no dependency, no build impact.