### PR TITLE
fix(examples): don't await state.startup() in the mount example — it deadlocks

### DIFF
--- a/python/examples/agent-server/src/service_mount.py
+++ b/python/examples/agent-server/src/service_mount.py
@@ -153,7 +153,12 @@ erc8183_app = create_erc8183_app(config=config, on_job=process_task, prefix="")
 async def lifespan(app: FastAPI):
     # Launch the funded-job poll loop (Starlette doesn't propagate lifespan to
     # mounted sub-apps, so we drive the erc8183 sub-app's startup ourselves).
-    await erc8183_app.state.startup()
+    #
+    # Do NOT await this. state.startup is a sync lambda that returns the
+    # poll loop's asyncio.Task; the loop only exits on shutdown, so awaiting
+    # it never returns and the lifespan never reaches `yield` - uvicorn would
+    # start up and never serve a request.
+    erc8183_app.state.startup()
     yield
 
 

--- a/python/examples/agent-server/tests/test_mount_startup.py
+++ b/python/examples/agent-server/tests/test_mount_startup.py
@@ -1,0 +1,81 @@
+"""``state.startup`` must not be awaited — regression guard for a mount deadlock.
+
+``create_erc8183_app`` exposes ``app.state.startup`` so a parent app can launch
+the funded-job poll loop itself (Starlette does not propagate lifespan events
+into mounted sub-apps). It is a *sync* lambda that returns the poll loop's
+``asyncio.Task``, and that loop only exits on shutdown — so ``await``-ing it
+never returns. A parent lifespan that awaited it would never reach ``yield``,
+and uvicorn would come up without ever serving a request.
+
+``service_mount.py`` did exactly that until this was fixed. These tests pin the
+contract that made it a bug.
+"""
+
+import asyncio
+import inspect
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from erc8183_server import create_erc8183_app
+
+
+def _fake_state():
+    """Same shape as the stub in test_routes_poll.py — no chain, no wallet."""
+    ops = MagicMock()
+    ops.agent_address = "0x" + "aa" * 20
+    ops.get_pending_jobs = AsyncMock(return_value={"success": True, "jobs": []})
+    state = MagicMock()
+    state.job_ops = ops
+    state.payment_token = ""
+    state.payment_token_decimals = 18
+    return state
+
+
+@pytest.fixture
+def app(monkeypatch):
+    monkeypatch.setattr(
+        "erc8183_server.create_erc8183_state",
+        lambda config: _fake_state(),
+    )
+    return create_erc8183_app(
+        config=MagicMock(),
+        on_job=lambda job: "done",
+        funded_poll_interval=0.02,
+    )
+
+
+def test_startup_is_a_sync_callable(app):
+    """The callable is sync, so ``await startup()`` awaits its *return value*."""
+    startup = app.state.startup
+    assert callable(startup)
+    assert not inspect.iscoroutinefunction(startup)
+
+
+def test_startup_returns_a_still_running_task(app):
+    """It hands back the live poll loop — which is why awaiting it blocks."""
+
+    async def drive():
+        task = app.state.startup()
+        assert isinstance(task, asyncio.Task)
+        await asyncio.sleep(0)  # give the loop a chance to start
+        assert not task.done()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(drive())
+
+
+def test_awaiting_startup_never_returns(app):
+    """The deadlock itself: mount code must call startup() without awaiting."""
+
+    async def drive():
+        task = app.state.startup()
+        with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(asyncio.shield(task), timeout=0.25)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+    asyncio.run(drive())


### PR DESCRIPTION
## Summary

`python/examples/agent-server/src/service_mount.py` is unrunnable as written. Its parent lifespan awaits `erc8183_app.state.startup()`:

```python
@asynccontextmanager
async def lifespan(app: FastAPI):
    await erc8183_app.state.startup()   # never returns
    yield
```

`state.startup` is assigned at [`erc8183_server.py:470`](../blob/main/python/examples/agent-server/src/erc8183_server.py) as:

```python
erc8183_app.state.startup = lambda: _spawn(_funded_poll_loop())
```

That is a **sync** lambda returning the poll loop's `asyncio.Task`. `_funded_poll_loop` is `while True`, exiting only when `stop_event` is set at shutdown. So `await startup()` awaits a Task that never completes: the lifespan never reaches `yield`, and uvicorn comes up without ever serving a request.

## Fix

Call it without awaiting — returning the Task is the point.

```python
erc8183_app.state.startup()
```

Plus a comment explaining why it must not be awaited, so it doesn't get "corrected" back.

## Tests

`service_mount.py` had **no test coverage**, which is why this shipped. Added `tests/test_mount_startup.py` pinning the three properties that made it a bug:

| Test | Asserts |
|---|---|
| `test_startup_is_a_sync_callable` | not a coroutine function — so `await` applies to the *return value* |
| `test_startup_returns_a_still_running_task` | returns an `asyncio.Task` that is not done |
| `test_awaiting_startup_never_returns` | awaiting that Task times out |

Uses the same `monkeypatch(create_erc8183_state)` stub convention as `test_routes_poll.py`, so no chain, wallet, or network access.

**Verified** with `fastapi 0.128.8` on Python 3.11:

```
before:  9 passed
after:  12 passed
```

## Notes for the maintainer

Two related things I did **not** change, since they are design calls rather than bugs:

1. `state.startup` is only assigned when `on_job` is passed (`erc8183_server.py:469-470`). Calling it on an app built without `on_job` raises `AttributeError` rather than being a no-op.
2. A sync callable returning a Task is easy to mis-await — exactly what happened here. An `async def startup()` that spawns and returns immediately would make the correct usage the natural one.

The same deadlock existed in the published docs (`docs.bnbchain.org` SDK quickstart, Option 2) and is fixed separately in [bnb-chain.github.io#882](https://github.com/bnb-chain/bnb-chain.github.io/pull/882).