### PR TITLE
docs: document the mpc wallet kind as a stub by design

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,22 @@ Every protocol client signs through the `WalletProvider` seam, so the wallet is 
 
 Details: [`python/bnbagent/wallets/README.md`](./python/bnbagent/wallets/README.md) (EVM + TWAK), [`typescript/README.md`](./typescript/README.md) (EVM + TWAK + Altana), [`docs/twak.md`](./docs/twak.md), and [`docs/altana.md`](./docs/altana.md).
 
+### Bring your own MPC custody
+
+`mpc` is a recognised wallet kind (`SUPPORTED_WALLET_KINDS = ("evm", "twak", "mpc")`) but is a **stub by design**. The SDK deliberately ships no in-process MPC implementation: threshold-key custody, audit trails, and policy enforcement belong in a dedicated provider (Coinbase CDP, Fireblocks, Web3Auth, and similar), which already solves them at the enclave level.
+
+Selecting it fails loudly rather than falling through silently:
+
+```python
+>>> from bnbagent.wallets.factory import create_wallet_provider
+>>> create_wallet_provider("mpc")
+NotImplementedError: MPC wallet support is not yet implemented. Please use EVMWalletProvider for now.
+```
+
+To sign through an MPC backend, adapt its API in your own project by subclassing `WalletProvider` (`from bnbagent.wallets import WalletProvider`). Implement only the `sign_*` methods your backend supports — `capabilities()` reports the matching `sign.*` entries from your overrides, and anything you leave alone raises a descriptive `UnsupportedWalletOperation`, so never override a method just to raise.
+
+`MPCWalletProvider` is exported for `isinstance` checks and as a subclassing reference, but its `__init__` raises unconditionally — subclass `WalletProvider` directly unless you also override `__init__`.
+
 ## Getting started
 
 ### Python

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Details: [`python/bnbagent/wallets/README.md`](./python/bnbagent/wallets/README.
 
 ### Bring your own MPC custody
 
-`mpc` is a recognised wallet kind (`SUPPORTED_WALLET_KINDS = ("evm", "twak", "mpc")`) but is a **stub by design**. The SDK deliberately ships no in-process MPC implementation: threshold-key custody, audit trails, and policy enforcement belong in a dedicated provider (Coinbase CDP, Fireblocks, Web3Auth, and similar), which already solves them at the enclave level.
+`mpc` is a recognised wallet kind (`SUPPORTED_WALLET_KINDS = ("evm", "twak", "mpc", "turnkey")`) but is a **stub by design**. The SDK deliberately ships no in-process MPC implementation: threshold-key custody, audit trails, and policy enforcement belong in a dedicated provider (Coinbase CDP, Fireblocks, Web3Auth, and similar), which already solves them at the enclave level.
 
 Selecting it fails loudly rather than falling through silently:
 


### PR DESCRIPTION
## Summary

The **Wallets** table in the root README lists `EVMWalletProvider`, `TWAKProvider` and `AltanaWalletProvider`. It never mentions `mpc` — the README contained **zero** occurrences of the string — yet:

- `SUPPORTED_WALLET_KINDS` is `("evm", "twak", "mpc")` (`python/bnbagent/wallets/factory.py:23`)
- `MPCWalletProvider` is exported from `bnbagent.wallets` and listed in its `__all__`
- `python/bnbagent/wallets/mpc_wallet_provider.py` ships in the package

So a reader comparing the table against the code finds a fourth provider and no way to tell whether it is usable, unfinished, or internal-only.

## It is none of those — it is an extension point

The module docstring is explicit that this is deliberate: the SDK does not ship in-process MPC because threshold-key custody, audit trails and policy enforcement belong in a dedicated provider (Coinbase CDP, Fireblocks, Web3Auth). The stub exists so `wallet.kind = "mpc"` fails loudly instead of falling through silently.

That intent was only visible in the source. This documents it in the README.

## Changes

A short `### Bring your own MPC custody` subsection after the wallets table covering:

- `mpc` is a recognised kind but a stub by design, and why
- the exact `NotImplementedError` the factory raises
- the subclassing path: subclass **`WalletProvider`**, implementing only the `sign_*` methods your backend supports (`capabilities()` reports the matching `sign.*` entries; anything left alone raises `UnsupportedWalletOperation`)
- a caveat that `MPCWalletProvider.__init__` raises unconditionally, so subclass `WalletProvider` directly unless you also override `__init__`

The existing three-row table and its "Three backends ship today" framing are unchanged — MPC is not a shipping backend and is deliberately not presented as a peer row.

## Verification

Against installed `bnbagent 0.4.3`:

```
SUPPORTED_WALLET_KINDS = ('evm', 'twak', 'mpc')
NotImplementedError: MPC wallet support is not yet implemented. Please use EVMWalletProvider for now.
```

The quoted traceback in the README reproduces verbatim. `UnsupportedWalletOperation` confirmed at `python/bnbagent/wallets/errors.py:16`; `WalletProvider` and `MPCWalletProvider` both confirmed importable from `bnbagent.wallets`.

Docs-only — no code, no dependency, no build impact.