### PR TITLE
docs(examples): TS SDK does ship TWAKProvider

### DIFF
--- a/typescript/examples/a2a-agent/.env.example
+++ b/typescript/examples/a2a-agent/.env.example
@@ -1,7 +1,8 @@
 # examples/a2a-agent — copy to .env and fill in your values.
 
 # ── Provider (src/server.ts + scripts/register.ts) ──
-# EVM only — the TypeScript SDK ships no TWAK wallet.
+# This example is EVM-only by choice. The TS SDK does ship TWAKProvider
+# (WALLET_KIND=twak); see typescript/README.md for that path.
 PRIVATE_KEY=0x...                      # provider wallet (signs quotes)
 WALLET_PASSWORD=demo-password
 NETWORK=bsc-testnet                    # bsc-testnet | bsc-mainnet

--- a/typescript/examples/a2a-agent/scripts/register.ts
+++ b/typescript/examples/a2a-agent/scripts/register.ts
@@ -5,8 +5,9 @@
  * (`{base}/.well-known/agent-card.json`) — built with `AgentEndpoint.a2a()`,
  * so buyers that discover this agent on-chain can fetch the card directly.
  *
- * TypeScript port of `python/examples/a2a-agent/scripts/register.py`
- * (EVM-only — the TS SDK ships no TWAK wallet).
+ * TypeScript port of `python/examples/a2a-agent/scripts/register.py`.
+ * This example is EVM-only by choice; the TS SDK does ship `TWAKProvider`
+ * (exported from `@bnbagent/sdk`) — see `typescript/README.md`.
  *
  * Run:
  *   pnpm -C typescript exec tsx examples/a2a-agent/scripts/register.ts

--- a/typescript/examples/agent-server/scripts/register.ts
+++ b/typescript/examples/agent-server/scripts/register.ts
@@ -7,8 +7,9 @@
  * spec-named types). For a protocol-typed registration see
  * `../../a2a-agent/scripts/register.ts`.
  *
- * TypeScript port of `python/examples/agent-server/scripts/register.py`
- * (EVM-only — the TS SDK ships no TWAK wallet).
+ * TypeScript port of `python/examples/agent-server/scripts/register.py`.
+ * This example is EVM-only by choice; the TS SDK does ship `TWAKProvider`
+ * (exported from `@bnbagent/sdk`) — see `typescript/README.md`.
  *
  * Run:
  *   pnpm -C typescript exec tsx examples/agent-server/scripts/register.ts


### PR DESCRIPTION
## Summary

Three TypeScript example files state that the TS SDK has no TWAK wallet:

- `typescript/examples/a2a-agent/scripts/register.ts:9`
- `typescript/examples/agent-server/scripts/register.ts:11`
- `typescript/examples/a2a-agent/.env.example:4`

> *"EVM-only — the TS SDK ships no TWAK wallet."*

That is not true:

| Evidence | Location |
|---|---|
| `TWAKProvider` is exported from `@bnbagent/sdk` | `typescript/src/index.ts:79` |
| Implementation ships | `typescript/src/wallets/twak/provider.ts:370` |
| `WALLET_KIND` accepts `twak` | env table, `typescript/README.md` |
| Root README lists TWAKProvider as **"Python + TypeScript"** | `README.md` wallets table |

This is the costly direction for a doc error: it tells a TypeScript user that a shipped wallet backend does not exist, so they never look for it.

## Fix

Reworded to state what is actually true — these examples are EVM-only *by choice* — and to point at the TWAK path for anyone who wants it. Comments and one `.env.example` line only; no code paths touched.

## Verification

`grep -rn "ships no TWAK"` across the repo now returns **zero** matches.