### PR TITLE
fix(release): prevent stale SDK version in npm bundles

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -627,6 +627,10 @@ jobs:
           pnpm run codegen
           git diff --exit-code src/abis
 
+      - name: Prepare or resume version
+        id: version
+        run: pnpm exec tsx scripts/release.ts prepare "${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
+
       - name: Check source and build
         run: |
           pnpm run typecheck
@@ -635,10 +639,6 @@ jobs:
           pnpm run test
           pnpm run build
           git diff --check
-
-      - name: Prepare or resume version
-        id: version
-        run: pnpm exec tsx scripts/release.ts prepare "${{ inputs.bump }}" >> "$GITHUB_OUTPUT"
 
       - name: Generate release notes
         env:
@@ -664,8 +664,36 @@ jobs:
       - name: Freeze workspace dependencies for publishing
         run: pnpm exec tsx scripts/release.ts freeze
 
-      - name: Package smoke test
-        run: pnpm exec tsx scripts/release.ts pack
+      - name: Pack and verify the installable tarball
+        env:
+          V: ${{ steps.version.outputs.version }}
+        run: |
+          set -euo pipefail
+          PACK_DIR="$RUNNER_TEMP/npm-pack"
+          CONSUMER_DIR="$(mktemp -d)"
+          mkdir -p "$PACK_DIR"
+          npm pack --json --pack-destination "$PACK_DIR" >/dev/null
+          mapfile -t TARBALLS < <(find "$PACK_DIR" -maxdepth 1 -type f -name '*.tgz')
+          if [[ "${#TARBALLS[@]}" -ne 1 ]]; then
+            echo "Expected exactly one tarball, found ${#TARBALLS[@]}" >&2
+            exit 1
+          fi
+          TARBALL_PATH="$PACK_DIR/bnbagent-sdk-$V.tgz"
+          if [[ "${TARBALLS[0]}" != "$TARBALL_PATH" ]]; then
+            echo "Unexpected tarball filename: ${TARBALLS[0]}" >&2
+            exit 1
+          fi
+          tar -xOf "$TARBALL_PATH" package/package.json |
+            jq -e --arg version "$V" \
+              '.name == "@bnbagent/sdk" and .version == $version' >/dev/null
+
+          cd "$CONSUMER_DIR"
+          npm init -y >/dev/null
+          npm install --ignore-scripts --no-audit --no-fund "$TARBALL_PATH"
+          node --input-type=module -e \
+            "await import('@bnbagent/sdk'); const { getBuiltWithValue } = await import('@bnbagent/sdk/erc8004'); const expected = 'https://github.com/bnb-chain/bnbagent-sdk#v' + process.env.V; if (getBuiltWithValue() !== expected) throw new Error('unexpected built_with version')"
+          node -e \
+            "require('@bnbagent/sdk'); require('@bnbagent/sdk/erc8004')"
 
       - name: Publish stable package with provenance
         run: pnpm exec tsx scripts/release.ts publish --tag latest

--- a/typescript/scripts/release.test.ts
+++ b/typescript/scripts/release.test.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import { expect, test } from "vitest";
 import {
   changelogLogArgs,
@@ -13,6 +14,13 @@ import {
 
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
+const publishWorkflow = readFileSync(
+  new URL("../../.github/workflows/npm-publish.yml", import.meta.url),
+  "utf8",
+);
+const productionJob = publishWorkflow.slice(
+  publishWorkflow.indexOf("\n  production:"),
+);
 
 test("release lock refresh routes installer output away from machine stdout", () => {
   const reported: string[] = [];
@@ -101,6 +109,19 @@ test("release publishes production explicitly under latest", () => {
     "--tag",
     "latest",
   ]);
+});
+
+test("production release versions the package before building it", () => {
+  const prepare = productionJob.indexOf("- name: Prepare or resume version");
+  const build = productionJob.indexOf("- name: Check source and build");
+
+  expect(prepare).toBeGreaterThan(-1);
+  expect(build).toBeGreaterThan(prepare);
+});
+
+test("production release verifies built_with from the installable tarball", () => {
+  expect(productionJob).toContain("npm pack --json");
+  expect(productionJob).toContain("getBuiltWithValue()");
 });
 
 test("publish waits for npm visibility before continuing", () => {


### PR DESCRIPTION
## Summary

- determine the production version before running `tsup` so the bundle inlines the release version
- install the real tarball in an isolated consumer and verify ERC-8004 `built_with` before publishing
- add regression tests that pin both release invariants

## Verification

- red: 2 new release tests failed against the previous workflow
- green: `scripts/release.test.ts` 13/13 passed
- full TypeScript suite: 50 files, 1160 passed, 1 skipped
- typecheck, examples typecheck, lint, and build passed
- local 0.5.3 tarball: manifest, CJS bundle, ESM import, and CJS require all reported 0.5.3
- PyPI sibling check: downloaded `bnbagent==0.4.4` wheel reports `__version__` and `built_with` as 0.4.4; Python release order is safe