### PR TITLE
fix(security): remediate audit round-2 new findings M01, M02

### DIFF
--- a/python/bnbagent/core/contract_mixin.py
+++ b/python/bnbagent/core/contract_mixin.py
@@ -17,22 +17,26 @@ from .nonce_manager import NonceManager
 logger = logging.getLogger(__name__)
 
 
+# Errors after which the transaction MAY have been accepted by the node, so
+# the nonce must be pinned BROADCAST and the local hash tracked. "nonce too
+# low" must NOT be listed here: it is a deterministic rejection (the tx never
+# entered the mempool) and has to fall through to NonceManager.handle_error()
+# so the stale local nonce is re-synced from chain and the send retried.
+AMBIGUOUS_SEND_ERROR_MARKERS = (
+    "429",
+    "too many requests",
+    "timeout",
+    "timed out",
+    "connection",
+    "network",
+    "already known",
+    "replacement transaction underpriced",
+)
+
+
 def _is_ambiguous_send_error(error: Exception) -> bool:
     text = str(error).lower()
-    return any(
-        marker in text
-        for marker in (
-            "429",
-            "too many requests",
-            "timeout",
-            "timed out",
-            "connection",
-            "network",
-            "already known",
-            "nonce too low",
-            "replacement transaction underpriced",
-        )
-    )
+    return any(marker in text for marker in AMBIGUOUS_SEND_ERROR_MARKERS)
 
 
 def _raw_bytes(signed: Any) -> bytes:

--- a/python/bnbagent/wallets/local_executor.py
+++ b/python/bnbagent/wallets/local_executor.py
@@ -30,6 +30,7 @@ from web3.contract.contract import ContractFunction
 from web3.exceptions import TimeExhausted
 
 from ..core.contract_mixin import (
+    AMBIGUOUS_SEND_ERROR_MARKERS,
     DEFAULT_RECEIPT_TIMEOUT,  # noqa: F401  — re-exported for back-compat
     MAX_RETRIES,
     MIN_GAS_PRICE_WEI,
@@ -76,20 +77,7 @@ def _signed_transaction_hash(raw_transaction: bytes) -> tuple[bytes, str]:
 def _is_ambiguous_broadcast_error(error: Exception) -> bool:
     """Whether a send failure may have happened after node acceptance."""
     text = str(error).lower()
-    return any(
-        marker in text
-        for marker in (
-            "429",
-            "too many requests",
-            "timeout",
-            "timed out",
-            "connection",
-            "network",
-            "already known",
-            "nonce too low",
-            "replacement transaction underpriced",
-        )
-    )
+    return any(marker in text for marker in AMBIGUOUS_SEND_ERROR_MARKERS)
 
 
 class LocalExecutor(IntentExecutor):

--- a/python/tests/test_contract_mixin.py
+++ b/python/tests/test_contract_mixin.py
@@ -236,3 +236,45 @@ class TestSendTxNonceLifecycle:
         assert result["status"] == 1
         assert mock_web3.eth.send_raw_transaction.call_count == 1
         assert mock_web3.eth.wait_for_transaction_receipt.call_count == 1
+
+
+class TestNonceTooLowResync:
+    """Audit R2 M01 regression: "nonce too low" is a deterministic rejection
+    (the tx never entered the mempool) and must re-sync + retry via
+    NonceManager.handle_error(), never be pinned BROADCAST as an ambiguous
+    send result."""
+
+    def test_nonce_too_low_is_not_ambiguous(self):
+        from bnbagent.core.contract_mixin import (
+            AMBIGUOUS_SEND_ERROR_MARKERS,
+            _is_ambiguous_send_error,
+        )
+        from bnbagent.wallets.local_executor import _is_ambiguous_broadcast_error
+
+        assert "nonce too low" not in AMBIGUOUS_SEND_ERROR_MARKERS
+        err = Exception("nonce too low: next nonce 5, tx nonce 2")
+        assert not _is_ambiguous_send_error(err)
+        assert not _is_ambiguous_broadcast_error(err)
+
+    def test_stale_local_nonce_resyncs_and_retries(self, client, mock_web3):
+        from tests.conftest import FAKE_TX_HASH
+
+        fn = _make_fn()
+        # Local view is stale (chain already at 5): seed reserve() with 2,
+        # then handle_error()'s re-sync reads 5.
+        mock_web3.eth.get_transaction_count.side_effect = [2, 5]
+        mock_web3.eth.send_raw_transaction.side_effect = [
+            Exception("nonce too low: next nonce 5, tx nonce 2"),
+            bytes.fromhex(FAKE_TX_HASH[2:]),
+        ]
+
+        result = client._send_tx(fn)
+
+        assert result["status"] == 1
+        assert mock_web3.eth.send_raw_transaction.call_count == 2
+        assert [
+            call.args[0]["nonce"] for call in fn.build_transaction.call_args_list
+        ] == [2, 5]
+        # the rejected nonce was released, not pinned BROADCAST
+        nonce_mgr = NonceManager.for_account(mock_web3, FAKE_ADDRESS)
+        assert nonce_mgr.broadcast_hash(2) is None

--- a/python/tests/test_erc8004_contract.py
+++ b/python/tests/test_erc8004_contract.py
@@ -401,18 +401,20 @@ class TestRetryAndNonceManagement:
         web3.eth.wait_for_transaction_receipt.return_value = ok_receipt
         return ci, web3, wallet_provider, fn, sent_hash
 
-    def test_send_nonce_conflict_is_not_blindly_rebroadcast(self):
-        """A send-time nonce conflict is ambiguous and tracks the local hash."""
+    def test_send_nonce_too_low_resyncs_and_retries(self):
+        """A send-time "nonce too low" is a deterministic rejection (the tx
+        never entered the mempool): re-sync the nonce and retry, never track
+        the local hash as an ambiguous broadcast (audit R2 M01)."""
         ci, web3, wallet_provider, fn, sent_hash = self._setup_for_retry()
-        # First send fails with nonce error, second succeeds.
+        # First send is rejected outright, retry with re-synced nonce succeeds.
         web3.eth.send_raw_transaction.side_effect = [
             Exception("nonce too low"),
             sent_hash,
         ]
         result = ci._execute_transaction(fn, description="retry-nonce")
-        assert web3.eth.send_raw_transaction.call_count == 1
+        assert web3.eth.send_raw_transaction.call_count == 2
         assert "transactionHash" in result
-        wallet_provider.sign_transaction.assert_called_once()
+        assert wallet_provider.sign_transaction.call_count == 2
 
     def test_send_rate_limit_is_ambiguous_and_not_rebroadcast(self):
         """A send-time 429 may follow acceptance, so it is never retried."""

--- a/typescript/src/wallets/keystore.ts
+++ b/typescript/src/wallets/keystore.ts
@@ -36,6 +36,11 @@ function passwordBytes(password: string): Uint8Array {
 const SCRYPT_N = 262_144;
 const SCRYPT_R = 8;
 const SCRYPT_P = 1;
+// Decrypt-side ceiling, deliberately wider than the write-side default above:
+// geth's light-KDF preset (`geth --lightkdf`) writes p=6, so pinning p to the
+// write default rejects valid wallets (audit R2 M02). DoS cost stays bounded
+// by SCRYPT_N/SCRYPT_R (memory scales with n*r; p is a small linear factor).
+const SCRYPT_P_MAX = 32;
 const DK_LEN = 32;
 const MAX_PBKDF2_ITERATIONS = 1_000_000;
 const MIN_SALT_BYTES = 16;
@@ -156,7 +161,7 @@ function validateKeystoreForDecrypt(keystore: KeystoreV3): void {
       throw new Error("scrypt n must be a power of two");
     }
     assertIntegerInRange(scryptParams.r, "scrypt r", 1, SCRYPT_R);
-    assertIntegerInRange(scryptParams.p, "scrypt p", 1, SCRYPT_P);
+    assertIntegerInRange(scryptParams.p, "scrypt p", 1, SCRYPT_P_MAX);
     return;
   }
   if (c.kdf === "pbkdf2") {

--- a/typescript/tests/fixtures/keystore-lightkdf-interop.json
+++ b/typescript/tests/fixtures/keystore-lightkdf-interop.json
@@ -1,0 +1,21 @@
+{
+  "address": "e239cdc5fbe977a8a141B72194D3CF8c41bC5BC6",
+  "crypto": {
+    "cipher": "aes-128-ctr",
+    "cipherparams": {
+      "iv": "1daf959c73cc491fb08dfe0a0a24fdfa"
+    },
+    "ciphertext": "9e9661228ce634580edfd3ee0eaef18c5f26a9dc68bd1b6d7c8c506d98131f1a",
+    "kdf": "scrypt",
+    "kdfparams": {
+      "dklen": 32,
+      "n": 4096,
+      "r": 8,
+      "p": 6,
+      "salt": "f83a9a5a29095d3d5a24159ae5fc7072"
+    },
+    "mac": "825e84b7fc472227d4c241a71f3ab9d1d18f71420a8f7cd8806abfa8732095c6"
+  },
+  "id": "9fa32f7a-8846-40c2-b536-1e340cee2cf7",
+  "version": 3
+}

--- a/typescript/tests/wallet.test.ts
+++ b/typescript/tests/wallet.test.ts
@@ -48,6 +48,12 @@ const PBKDF2_FIXTURE_PATH = join(
   "keystore-pbkdf2-interop.json",
 );
 
+const LIGHTKDF_FIXTURE_PATH = join(
+  fileURLToPath(new URL(".", import.meta.url)),
+  "fixtures",
+  "keystore-lightkdf-interop.json",
+);
+
 let wdir: string;
 
 beforeEach(() => {
@@ -470,6 +476,27 @@ describe("keystore interop — Python eth_account -> TS", () => {
     Object.assign(fixture.crypto.kdfparams, { n: 2 ** 30 });
     expect(() => decryptKeystoreV3(fixture, "test-password")).toThrow(
       /scrypt n exceeds supported maximum/,
+    );
+  });
+
+  it("decrypts a geth light-KDF keystore (n=4096, r=8, p=6) — audit R2 M02", () => {
+    // Fixture matches `geth --lightkdf` (LightScryptN=4096, LightScryptP=6);
+    // p must not be pinned to the write-side default of 1.
+    const fixture = JSON.parse(
+      readFileSync(LIGHTKDF_FIXTURE_PATH, "utf8"),
+    ) as KeystoreV3;
+    expect((fixture.crypto.kdfparams as { p: number }).p).toBe(6);
+    const recovered = decryptKeystoreV3(fixture, "test-password");
+    expect(toHexString(recovered)).toBe("ab".repeat(32));
+  });
+
+  it("rejects scrypt p above the interop ceiling before running its KDF", () => {
+    const fixture = JSON.parse(
+      readFileSync(LIGHTKDF_FIXTURE_PATH, "utf8"),
+    ) as KeystoreV3;
+    Object.assign(fixture.crypto.kdfparams, { p: 33 });
+    expect(() => decryptKeystoreV3(fixture, "test-password")).toThrow(
+      /scrypt p exceeds supported maximum/,
     );
   });
 


### PR DESCRIPTION
Remediates the two Medium findings from the **New Findings** section of the HashDit audit report (round 2, Aug 11–25 2026), both regressions introduced by the PR #80 remediation.

## [R2 M01] "nonce too low" misclassified as ambiguous broadcast (Python)

The PR #80 nonce rework classified `"nonce too low"` as an ambiguous send result, pinning the nonce BROADCAST and blocking ~300s in receipt-wait — while `NonceManager.handle_error()`'s re-sync became unreachable for the exact error it names. `reset()` preserves BROADCAST entries, so the account stayed wedged.

- Drop `"nonce too low"` from the ambiguous marker set: it is a deterministic rejection (the tx never entered the mempool), so it now falls through to `handle_error()` → chain re-sync → retry.
- Merge the two duplicated marker lists (`contract_mixin` / `local_executor`) into one shared `AMBIGUOUS_SEND_ERROR_MARKERS` constant — the duplication is how the sets drifted into this regression — with a comment stating why `"nonce too low"` must never be added back.
- Tests: marker-set assertion; stale-local-nonce scenario (local 2, chain 5) asserting re-sync + retry succeeds and nonce 2 is not pinned; rewrote `test_send_nonce_conflict_is_not_blindly_rebroadcast`, which had locked in the buggy behavior.

## [R2 M02] Keystore validation pins scrypt p to exactly 1 (TypeScript)

The PR #80 keystore hardening bound the decrypt-side `p` ceiling to the SDK's own write-side default of 1, rejecting valid geth light-KDF wallets (`geth --lightkdf` writes p=6) before the KDF even runs.

- Split the decrypt-side ceiling (`SCRYPT_P_MAX = 32`, per the audit recommendation) from the write-side default (`SCRYPT_P = 1`, encryption path unchanged). DoS cost stays bounded by the existing n/r ceilings — scrypt memory scales with `128·n·r`; p is a small linear CPU factor.
- Adds a light-KDF interop fixture (`n=4096, r=8, p=6`) generated and independently round-tripped through `eth_account.Account.decrypt`; tests assert it decrypts and that `p=33` is rejected.

## Verification

- Python: 895 passed (`uv run pytest`), `ruff check` clean
- TypeScript: 1196 passed, `typecheck`, `typecheck:examples`, `lint`, `build` all green