### PR TITLE
fix(typescript): preserve RPC revert data across SDK errors

### DIFF
--- a/typescript/src/core/txSender.ts
+++ b/typescript/src/core/txSender.ts
@@ -170,7 +170,9 @@ export async function estimateGasLimit(
       return DEFAULT_GAS_FALLBACK;
     }
     if (describeError(error).toLowerCase().includes("revert")) {
-      throw new Error(`Transaction would revert: ${describeError(error)}`);
+      throw new Error(`Transaction would revert: ${describeError(error)}`, {
+        cause: error,
+      });
     }
     console.warn(
       `${logPrefix} Gas estimation unavailable (${describeError(error)}); falling back to gas=${DEFAULT_GAS_FALLBACK}`,
@@ -463,6 +465,7 @@ export async function sendSelfPayTx(
           } else {
             throw new Error(
               `Transaction would revert: ${describeError(preflight.error)}`,
+              { cause: preflight.error },
             );
           }
         }

--- a/typescript/src/erc8183/jobOps.ts
+++ b/typescript/src/erc8183/jobOps.ts
@@ -125,6 +125,37 @@ function findRpcErrorCode(exc: unknown): number | undefined {
   return undefined;
 }
 
+/** Preserve a revert selector without exposing RPC URLs or encoded arguments. */
+function findRevertSelector(exc: unknown): string | undefined {
+  const seen = new Set<object>();
+  let current = exc;
+  let reverted = false;
+  while (
+    current !== null &&
+    typeof current === "object" &&
+    !seen.has(current)
+  ) {
+    seen.add(current);
+    const error = current as {
+      message?: unknown;
+      data?: unknown;
+      cause?: unknown;
+    };
+    reverted ||=
+      typeof error.message === "string" &&
+      /\brevert(?:ed)?\b/i.test(error.message);
+    if (
+      reverted &&
+      typeof error.data === "string" &&
+      /^0x[0-9a-f]{8}(?:[0-9a-f]{64})*$/i.test(error.data)
+    ) {
+      return error.data.slice(0, 10).toLowerCase();
+    }
+    current = error.cause;
+  }
+  return undefined;
+}
+
 /** Full transient-keyword list used by {@link excErrorFields}. */
 const TRANSIENT_ERROR_KEYWORDS = [
   "timeout",
@@ -243,6 +274,10 @@ export function excErrorFields(exc: unknown): Record<string, unknown> {
   } else {
     const redacted = message.replace(/\S+:\/\/\S+/g, "<redacted>");
     fields = { error: redacted, error_code: ERR_INTERNAL, retryable: true };
+  }
+  const selector = findRevertSelector(exc);
+  if (selector !== undefined) {
+    fields.error += ` (execution reverted: ${selector})`;
   }
   if (rpcCode !== undefined) {
     fields.rpc_error_code = rpcCode;

--- a/typescript/tests/contractBase.test.ts
+++ b/typescript/tests/contractBase.test.ts
@@ -7,6 +7,7 @@ import {
   _resetTxConfigOverrides,
   setDefaultReceiptTimeout,
 } from "../src/core/txConfig.js";
+import { excErrorFields } from "../src/erc8183/jobOps.js";
 import { TransactionPendingError } from "../src/errors.js";
 import type {
   ExecutionContext,
@@ -165,6 +166,46 @@ describe("sendTx: read-only guard", () => {
       "wallet_provider is required for write operations (client is read-only)",
     );
   });
+});
+
+describe("sendTx: structured RPC revert data", () => {
+  it.each(["eth_estimateGas", "eth_call"])(
+    "preserves the RPC cause and envelope selector from %s",
+    async (method) => {
+      const rpcError = {
+        code: 3,
+        message: "execution reverted",
+        data: "0x32d53d69",
+      };
+      const { contract, wallet, mock } = makeContract({
+        handlers: {
+          [method]: () => {
+            throw rpcError;
+          },
+        },
+      });
+      const error = await contract
+        .callSendTx({ functionName: "setValue", args: [1n] })
+        .catch((error: unknown) => error);
+      expect(error).toBeInstanceOf(Error);
+      const causes: unknown[] = [];
+      let current = error;
+      while (
+        current !== null &&
+        typeof current === "object" &&
+        !causes.includes(current)
+      ) {
+        causes.push(current);
+        current = (current as Error).cause;
+      }
+      expect(causes).toContain(rpcError);
+      expect(excErrorFields(error).error).toContain(
+        "execution reverted: 0x32d53d69",
+      );
+      expect(wallet.signedTxs).toHaveLength(0);
+      expect(sendRawCount(mock)).toBe(0);
+    },
+  );
 });
 
 describe("sendTx: gas estimation", () => {

--- a/typescript/tests/erc8183JobOps.test.ts
+++ b/typescript/tests/erc8183JobOps.test.ts
@@ -1325,6 +1325,44 @@ describe("excErrorFields", () => {
     expect(fields.error_code).toBe("chain_unavailable");
   });
 
+  it("preserves only the selector of a nested parameterized revert across JSON serialization", () => {
+    const rpcError = {
+      code: 3,
+      message: "execution reverted",
+      data: `0x118cdaa7${"ab".repeat(32)}`,
+      url: "https://rpc.example/SECRET",
+    };
+    const error = new Error("RPC request failed", { cause: rpcError });
+    const fields = JSON.parse(JSON.stringify(excErrorFields(error)));
+    expect(fields.error).toBe(
+      "Temporary chain/RPC error (execution reverted: 0x118cdaa7)",
+    );
+    expect(fields.error_code).toBe("chain_unavailable");
+    expect(fields.retryable).toBe(true);
+    expect(fields.rpc_error_code).toBe(3);
+    expect(JSON.stringify(fields)).not.toContain("SECRET");
+    expect(JSON.stringify(fields)).not.toContain("ab".repeat(32));
+  });
+
+  it.each([
+    "0x",
+    "0x32d53d69ff",
+    `0x${"ab".repeat(20)}`,
+    `0x${"ab".repeat(32)}`,
+  ])("does not invent a selector from malformed/opaque data %s", (data) => {
+    const fields = excErrorFields({ message: "execution reverted", data });
+    expect(fields.error).toBe("execution reverted");
+  });
+
+  it("does not treat request calldata as revert data and terminates on cyclic causes", () => {
+    const error = Object.assign(new Error("request failed"), {
+      data: "0x32d53d69",
+      cause: undefined as unknown,
+    });
+    error.cause = error;
+    expect(excErrorFields(error).error).toBe("request failed");
+  });
+
   it("passes a revert reason through unchanged", () => {
     const fields = excErrorFields(
       new Error("Transaction would revert: NotProvider"),


### PR DESCRIPTION
RPCs can return `message: "execution reverted"` with the custom-error selector only in `data`. The SDK discarded that data when wrapping gas-estimation/preflight failures, and job-operation error envelopes dropped it again. Preserve the original cause and append a validated four-byte selector to the existing error string so consumers can decode errors such as `PolicyNotSet()` after either an exception or JSON serialization.

Error codes, retry flags, URL redaction, signing, and broadcast behavior remain unchanged. The envelope includes no additional RPC URLs or encoded error arguments. Studio will need a published SDK version and dependency upgrade to consume this fix.

Validation:
- Reproduced three failures before the fix; the focused suite passes 109 tests afterward.
- Full TypeScript suite: 1204 passed, 1 skipped; source/example typechecks, lint, build, ABI drift check, and both offline examples passed.
- Built SDK interoperates with Studio's decoder through both the preserved cause and the serialized failure envelope.
- `npm pack --dry-run`: 72 files, no source or tests included.
- Reviewed all `Transaction would revert` wrappers and the shared job-operation envelope; independent security review found no introduced issues.
