### PR TITLE
chore(release): prepare SDK v0.5.6

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bnbagent/sdk",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "description": "TypeScript SDK for building on-chain AI agents on BNB Chain (ERC-8004 identity, ERC-8183 agentic commerce, x402 payments).",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Prepare `@bnbagent/sdk@0.5.6` to publish the RPC revert-data fix merged in #87. The production workflow will use `bump=current`, so it publishes the reviewed version without writing a version commit directly to main.

Only the package version changes. The release helper regenerated the lockfile without changes; its 13 tests pass, and `prepare current` reports `version=0.5.6` and `commit=false`. The merged source has passed TypeScript CI.
